### PR TITLE
New parameters for connections and changes to robotic plant lock mechanism

### DIFF
--- a/complete_control/config/connection_params.py
+++ b/complete_control/config/connection_params.py
@@ -17,7 +17,7 @@ class ConnectionsParams(BaseModel):
 
     dcn_forw_prediction: SingleSynapseParams = Field(
         default_factory=lambda: SingleSynapseParams(
-            weight=0.3,
+            weight=0.0055,
             delay=0.1,
         )
     )
@@ -47,7 +47,7 @@ class ConnectionsParams(BaseModel):
     )
     state_mc_fbk: SingleSynapseParams = Field(
         default_factory=lambda: SingleSynapseParams(
-            weight=-0.95,
+            weight=-1.2,
             delay=0.1,
         )
     )
@@ -71,7 +71,7 @@ class ConnectionsParams(BaseModel):
     )
     error_io_f: SingleSynapseParams = Field(
         default_factory=lambda: SingleSynapseParams(
-            weight=3.0,
+            weight=0.04,
             delay=0.1,
             receptor_type=1,
         )
@@ -82,9 +82,21 @@ class ConnectionsParams(BaseModel):
             delay=0.1,
         )
     )
+    state_state_to_inv: SingleSynapseParams = Field(
+        default_factory=lambda: SingleSynapseParams(
+            weight=0.020,
+            delay=0.1,
+        )
+    )
     planner_error_inv: SingleSynapseParams = Field(
         default_factory=lambda: SingleSynapseParams(
             weight=0.001,
+            delay=0.1,
+        )
+    )
+    state_to_inv_error_inv: SingleSynapseParams = Field(
+        default_factory=lambda: SingleSynapseParams(
+            weight=-0.001,
             delay=0.1,
         )
     )
@@ -144,7 +156,7 @@ class ConnectionsParams(BaseModel):
     )
     error_inv_io_i: SingleSynapseParams = Field(
         default_factory=lambda: SingleSynapseParams(
-            weight=3.0,
+            weight=0.9,
             delay=0.1,
             receptor_type=1,
         )

--- a/complete_control/draw_schema.py
+++ b/complete_control/draw_schema.py
@@ -302,7 +302,7 @@ def draw_schema(run_paths: RunPaths, scale_factor: float = 0.005):
             "",
             "",
             0,
-            neural_figs_path / "fbk_smooth_0.png",
+            neural_figs_path / "mc_fbk_0.png",
         ),
         # --- Brain Stem ---
         "Smoothing": (
@@ -489,12 +489,12 @@ def draw_schema(run_paths: RunPaths, scale_factor: float = 0.005):
                 components["Mf_inv"][1] + components["Mf_inv"][3] / 2,
             ),
         ],
-        "plan_inv_to_error_inv": [
+        "plan_to_error_inv": [
             (
-                components["plan to inv"][0] + components["plan to inv"][2],
-                components["plan to inv"][1] + 0.5,
+                components["Planner"][0] + components["Planner"][2],
+                components["Planner"][1] + 0.5,
             ),
-            (components["error inv"][0] + 2, components["plan to inv"][1] + 0.5),
+            (components["error inv"][0] + 2, components["Planner"][1] + 0.5),
             (
                 components["error inv"][0] + 2,
                 components["error inv"][1] + components["error inv"][3],
@@ -703,7 +703,7 @@ def draw_schema(run_paths: RunPaths, scale_factor: float = 0.005):
 
     draw_path(paths["planner_to_plan_inv"], "dimgray")
     draw_path(paths["plan_inv_to_mf"], "dimgray")
-    draw_path(paths["plan_inv_to_error_inv"], "dimgray")
+    draw_path(paths["plan_to_error_inv"], "dimgray")
     draw_path(paths["planner_to_fbk"], "dimgray")
     draw_path(paths["error_inv_to_io"], "orchid")
     draw_path(paths["state_to_state_inv"], "dimgray")

--- a/complete_control/neural/CerebellumHandler.py
+++ b/complete_control/neural/CerebellumHandler.py
@@ -530,9 +530,7 @@ class CerebellumHandler:
             syn_spec=syn_spec_n,
         )
 
-        # Connect StateEst -> Inv Error (Inhibitory?)
-        # TODO why is this called "plan" when it is the state? Using same spec for now.
-        state_err_inv_spec = self.conn_params.plan_to_inv_error_inv
+        state_err_inv_spec = self.conn_params.state_to_inv_error_inv
         syn_spec_p = state_err_inv_spec.model_dump(exclude_none=True)
         syn_spec_n = state_err_inv_spec.model_copy(
             update={"weight": -state_err_inv_spec.weight}
@@ -720,10 +718,8 @@ class CerebellumHandler:
             syn_spec=syn_spec_n,
         )
 
-        # StateEst -> Cereb State To Inv Input
-        # TODO: Check if "planner_plan_to_inv" is the correct conn_spec or if a dedicated one like "state_state_to_inv" is needed.
         state_sti_spec = (
-            self.conn_params.planner_plan_to_inv
+            self.conn_params.state_state_to_inv
         )  # Using planner_plan_to_inv as per existing code
         syn_spec_p = state_sti_spec.model_dump(exclude_none=True)
         syn_spec_n = state_sti_spec.model_copy(

--- a/complete_control/neural/plot_utils.py
+++ b/complete_control/neural/plot_utils.py
@@ -202,6 +202,7 @@ def plot_population_single(
     ax[0].set_ylabel("raster", fontsize=15)
     ax[0].set_title(title, fontsize=16)
     ax[0].set_ylim(bottom=0, top=pop_data.population_size + 1)
+
     for i, axs in enumerate(ax):
         axs.spines["top"].set_visible(False)
         axs.spines["right"].set_visible(False)
@@ -277,6 +278,7 @@ def plot_controller_outputs(run_paths: RunPaths):
         "brainstem",
         "mc_out",
         "mc_ffwd",
+        "mc_fbk",
         "state",
         "sensoryneur",
         "cereb_core_forw_dcnp",

--- a/complete_control/plant/plant_simulator.py
+++ b/complete_control/plant/plant_simulator.py
@@ -195,18 +195,28 @@ class PlantSimulator:
         time_in_trial = current_sim_time_s % self.config.TIME_TRIAL_S
         return (self.config.TIME_PREP_S + self.config.TIME_MOVE_S) < time_in_trial
 
-    def _should_lock_joint(self, current_sim_time_s: float) -> bool:
+    def _should_lock_joint_post(self, current_sim_time_s: float) -> bool:
         time_in_trial = current_sim_time_s % self.config.TIME_TRIAL_S
         # joint is locked in two situations:
         # 1. during TIME_POST: we keep the joint locked at his arrival place
         # 2. during TIME_PREP: state needs time to adapt to sensory
         return (
             self.config.TIME_PREP_S + self.config.TIME_MOVE_S
-        ) < time_in_trial or time_in_trial < self.config.TIME_PREP_S
+        ) < time_in_trial and time_in_trial > self.config.TIME_PREP_S
+
+    def _should_lock_joint_pre(self, current_sim_time_s: float) -> bool:
+        time_in_trial = current_sim_time_s % self.config.TIME_TRIAL_S
+        # joint is locked in two situations:
+        # 1. during TIME_POST: we keep the joint locked at his arrival place
+        # 2. during TIME_PREP: state needs time to adapt to sensory
+        return time_in_trial < self.config.TIME_PREP_S
 
     def _set_joint_torque(self, joint_torque: float, current_sim_time_s: float) -> bool:
-        if self._should_lock_joint(current_sim_time_s):
-            self.plant.lock_joint()
+        if self._should_lock_joint_pre(current_sim_time_s):
+            self.plant.lock_joint_pre()
+            return
+        if self._should_lock_joint_post(current_sim_time_s):
+            self.plant.lock_joint_post()
             return
         self.plant.set_joint_torques([joint_torque])
 

--- a/complete_control/plant/plant_simulator.py
+++ b/complete_control/plant/plant_simulator.py
@@ -200,9 +200,7 @@ class PlantSimulator:
         # joint is locked in two situations:
         # 1. during TIME_POST: we keep the joint locked at his arrival place
         # 2. during TIME_PREP: state needs time to adapt to sensory
-        return (
-            self.config.TIME_PREP_S + self.config.TIME_MOVE_S
-        ) < time_in_trial and time_in_trial > self.config.TIME_PREP_S
+        return (self.config.TIME_PREP_S + self.config.TIME_MOVE_S) < time_in_trial
 
     def _should_lock_joint_pre(self, current_sim_time_s: float) -> bool:
         time_in_trial = current_sim_time_s % self.config.TIME_TRIAL_S


### PR DESCRIPTION
- New parameters for connections and new connections are added to the base after testing.
- New lock mechanism added. Because for pre-time, it should use initial_joint_position_rad to stay at the beginning; reset_plant is not working well. On the other hand, in the post time, current_joint_pos_rad should be used to maintain the location so that the robot can come from there. Now it is working, and you can find the result below:

<img width="9360" height="8145" alt="image" src="https://github.com/user-attachments/assets/253cf4f1-e20e-4ed0-bc7b-29513ca8cfc7" />
