### PR TITLE
refactor: black formatting

### DIFF
--- a/complete_control/deprecated/settings.py
+++ b/complete_control/deprecated/settings.py
@@ -12,103 +12,162 @@ import sys
 import numpy as np
 
 # Just to get the following imports right!
-sys.path.insert(1, '../')
+sys.path.insert(1, "../")
 
-#import perturbation as pt
+# import perturbation as pt
 import os
 
 from robot1j import Robot1J
 
 SEED = 12345
 
+
 ####################################################################
 class Experiment:
 
     def __init__(self):
 
-
         self._cond = "test_plot_"
-        
+
         # Where to save data
         self._pathData = "./data/"
         self._pathFig = "./figures_thesis/cloop_cereb/"
 
         if not os.path.exists(self._pathData):
             os.mkdir(self._pathData)
-        
+
         if not os.path.exists(self._pathFig):
             os.mkdir(self._pathFig)
 
-
         # Initial and target position (end-effector space)
-        self._init_pos = np.ndarray([1,2])
-        self._tgt_pos  = np.ndarray([1,2])
-        
+        self._init_pos = np.ndarray([1, 2])
+        self._tgt_pos = np.ndarray([1, 2])
+
         ### FULL FLEXION (0 -> 90)
-        #self._init_pos[:] = [0.31, 0.0]
-        #self._tgt_pos[:]  =[0.0,0.31]
-        
+        # self._init_pos[:] = [0.31, 0.0]
+        # self._tgt_pos[:]  =[0.0,0.31]
+
         ### FULL EXTENSION (90 -> 0)
-        #self._init_pos[:] = [0.0,0.31]
-        #self._tgt_pos[:]  =[0.31,0.0]
-        
+        # self._init_pos[:] = [0.0,0.31]
+        # self._tgt_pos[:]  =[0.31,0.0]
+
         ### LOWER HALF FLEXION (0 -> 45)
-        #self._init_pos[:] = [0.31, 0.0]
-        #self._tgt_pos[:]  =[0.219,0.219]
+        # self._init_pos[:] = [0.31, 0.0]
+        # self._tgt_pos[:]  =[0.219,0.219]
 
         ### UPPER HALF FLEXION (45 -> 90)
-        #self._init_pos[:]  =[0.219,0.219]
-        #self._tgt_pos[:]  =[0.0,0.31]
+        # self._init_pos[:]  =[0.219,0.219]
+        # self._tgt_pos[:]  =[0.0,0.31]
 
         ### LOWER HALF EXTENSION (45 -> 0)
-        self._init_pos[:]  =[0.219,0.219]
+        self._init_pos[:] = [0.219, 0.219]
         self._tgt_pos[:] = [0.31, 0.0]
 
         ### UPPER HALF EXTENSION (90 -> 45)
-        #self._init_pos[:] = [0.0,0.31]
-        #self._tgt_pos[:]  =[0.219,0.219]
-        
+        # self._init_pos[:] = [0.0,0.31]
+        # self._tgt_pos[:]  =[0.219,0.219]
 
         # self._init_pos[:] = [-0.00155569,1.16870009]
         # self._tgt_pos[:]  =[-0.00155569+0.31,1.16870009+0.31]
-        #self._tgt_pos  = np.array([0.25,0.43])
-        #self._tgt_pos  = np.array([-0.25,0.43])
+        # self._tgt_pos  = np.array([0.25,0.43])
+        # self._tgt_pos  = np.array([-0.25,0.43])
 
         # Perturbation
-        alpha = 0#np.arctan(self._tgt_pos[:,1]/self._tgt_pos[:,0])/np.pi*180
-        left = (180 - alpha)
+        alpha = 0  # np.arctan(self._tgt_pos[:,1]/self._tgt_pos[:,0])/np.pi*180
+        left = 180 - alpha
         right = -alpha
-        self._frcFld_angle = right  # Angle of the perturbation force wrt movement velocity
-        self._frcFld_k     = 2       # Gain of the perturbation force wrt movement velocity
-        self._ff_application = 1e6    # Trial at which the Force Field is applied (1e6 = no force field)
-        self._ff_removal = 1e6    # Trial at which the Force Field is removed for extinction
+        self._frcFld_angle = (
+            right  # Angle of the perturbation force wrt movement velocity
+        )
+        self._frcFld_k = 2  # Gain of the perturbation force wrt movement velocity
+        self._ff_application = (
+            1e6  # Trial at which the Force Field is applied (1e6 = no force field)
+        )
+        self._ff_removal = (
+            1e6  # Trial at which the Force Field is removed for extinction
+        )
 
         # Dynamical system
-        self._robot_spec = {"mass": np.array([1.89]),
-                    "links":np.array([0.31]),
-                    "I": np.array([0.00189])} #0.00189
-        self._dynSys     = Robot1J(robot=self._robot_spec)
-        self._dynSys.pos = self._dynSys.inverseKin(pos_external = self._init_pos) # Place dyn sys in desired initial position
-        self._dynSys.vel = np.array([0.0])      # with zero initial velocity
-        
+        self._robot_spec = {
+            "mass": np.array([1.89]),
+            "links": np.array([0.31]),
+            "I": np.array([0.00189]),
+        }  # 0.00189
+        self._dynSys = Robot1J(robot=self._robot_spec)
+        self._dynSys.pos = self._dynSys.inverseKin(
+            pos_external=self._init_pos
+        )  # Place dyn sys in desired initial position
+        self._dynSys.vel = np.array([0.0])  # with zero initial velocity
+
         # At which trial Cerebellum connected to StateEstimator
         self._cerebellum_application_forw = 1e6
 
         self._cerebellum_application_inv = 1e6
 
-        self.names = ["planner_p", "planner_n", "ffwd_p", "ffwd_n", "fbk_p", "fbk_n", "out_p", "out_n", "brainstem_p", "brainstem_n", "sn_p", "sn_n", "pred_p", "pred_n", "state_p", "state_n", "forw_mf_plus", "forw_mf_minus", "forw_dcnp+", "forw_dcnp-", "forw_io+", "forw_io-", "inv_mf_plus", "inv_mf_minus", "inv_dcnp+", "inv_dcnp-", "inv_io+", "inv_io-", "feedback_p", "feedback_n", "motor_commands_p", "motor_commands_n", "error_p", "error_n", "plan_to_inv_p", "plan_to_inv_n", "motor_prediction_p", "motor_prediction_n", "feedback_inv_p", "feedback_inv_n", "error_inv_p", "error_inv_n", "forw_pc+", "forw_pc-", "inv_pc+", "inv_pc-", "state_to_inv_p", "state_to_inv_n"]
+        self.names = [
+            "planner_p",
+            "planner_n",
+            "ffwd_p",
+            "ffwd_n",
+            "fbk_p",
+            "fbk_n",
+            "out_p",
+            "out_n",
+            "brainstem_p",
+            "brainstem_n",
+            "sn_p",
+            "sn_n",
+            "pred_p",
+            "pred_n",
+            "state_p",
+            "state_n",
+            "forw_mf_plus",
+            "forw_mf_minus",
+            "forw_dcnp+",
+            "forw_dcnp-",
+            "forw_io+",
+            "forw_io-",
+            "inv_mf_plus",
+            "inv_mf_minus",
+            "inv_dcnp+",
+            "inv_dcnp-",
+            "inv_io+",
+            "inv_io-",
+            "feedback_p",
+            "feedback_n",
+            "motor_commands_p",
+            "motor_commands_n",
+            "error_p",
+            "error_n",
+            "plan_to_inv_p",
+            "plan_to_inv_n",
+            "motor_prediction_p",
+            "motor_prediction_n",
+            "feedback_inv_p",
+            "feedback_inv_n",
+            "error_inv_p",
+            "error_inv_n",
+            "forw_pc+",
+            "forw_pc-",
+            "inv_pc+",
+            "inv_pc-",
+            "state_to_inv_p",
+            "state_to_inv_n",
+        ]
 
     def remove_files(self):
         for f in os.listdir(self._pathData):
-            if '.gdf' in f or '.dat' in f or '.txt' in f or '.csv' in f:
-                os.remove(self._pathData+f)
+            if ".gdf" in f or ".dat" in f or ".txt" in f or ".csv" in f:
+                os.remove(self._pathData + f)
 
     @property
     def pathData(self):
         return self._pathData
+
     @property
     def param_file(self):
         return self._param_file
+
     @property
     def cond(self):
         return self._cond
@@ -159,7 +218,7 @@ class Experiment:
 
 
 ####################################################################
-class Simulation():
+class Simulation:
 
     def __init__(self):
 
@@ -177,7 +236,6 @@ class Simulation():
 
         # Waiting time before movement execution (milliseconds)
         self.timeWait = 150.0
-
 
     @property
     def resolution(self):
@@ -197,7 +255,7 @@ class Simulation():
 
 
 ####################################################################
-class Brain():
+class Brain:
 
     def __init__(self):
 
@@ -211,12 +269,12 @@ class Brain():
         self._filename_h5 = "mouse_cereb_microzones_nest.hdf5"
 
         # JSON configuration file
-        self._filename_config = 'microzones_nest.yaml'
+        self._filename_config = "microzones_nest.yaml"
 
         # self.initPlanner()        # Initialize planner settings
-        self.initMotorCortex()    # Initialize motor cortex settings
+        self.initMotorCortex()  # Initialize motor cortex settings
         # self.initStateEstimator() # Initialize state estimator
-        self.initSpine()          # Initialize spinal cord settings
+        self.initSpine()  # Initialize spinal cord settings
 
         # self._connections = {
         #     "wgt_plnr_mtxFbk"  :  1.0, # Connection weight (excitatory) between Planner and Motor Cortex FBK
@@ -224,17 +282,16 @@ class Brain():
         #     "wgt_spine_stEst"  :  1.0  # Connection weigth (excitatory) between Spine and State Estimator
         # }
 
-
     # def initPlanner(self):
 
-        # # Replanning gain
-        # self._kpl = 0.5
+    # # Replanning gain
+    # self._kpl = 0.5
 
-        # # Population parameteres
-        # self._plan_param = {
-        #     "base_rate":  0.0, # Base rate
-        #     "kp":      1200.0  # Gain
-        #     }
+    # # Population parameteres
+    # self._plan_param = {
+    #     "base_rate":  0.0, # Base rate
+    #     "kp":      1200.0  # Gain
+    #     }
 
     def initMotorCortex(self):
 
@@ -254,21 +311,23 @@ class Brain():
         #     }
 
     # def initStateEstimator(self):
-        # Not used for StateEstimator Massimo TODO
+    # Not used for StateEstimator Massimo TODO
 
-        # self._k_prediction = 0.0     # Reiability of the prediction input of the state estimator
-        # self._k_sensory    = 1.0     # Reiability of the sensory feedback input of the state estimator
+    # self._k_prediction = 0.0     # Reiability of the prediction input of the state estimator
+    # self._k_sensory    = 1.0     # Reiability of the sensory feedback input of the state estimator
 
-        # self._stEst_param = {
-        #     "out_base_rate":  0.0,   # Summation neurons (i.e. basic_neurons)
-        #     "out_kp":         1.0,   # Gain of the output neurons
-        #     "wgt_scale":      1.0,   # Scale of connection weight from input to output populations (must be positive)
-        #     "buf_sz":        10.0    # Size of the buffer to compute spike rate in basic_neurons (ms)
-        #     }
+    # self._stEst_param = {
+    #     "out_base_rate":  0.0,   # Summation neurons (i.e. basic_neurons)
+    #     "out_kp":         1.0,   # Gain of the output neurons
+    #     "wgt_scale":      1.0,   # Scale of connection weight from input to output populations (must be positive)
+    #     "buf_sz":        10.0    # Size of the buffer to compute spike rate in basic_neurons (ms)
+    #     }
 
     def initSpine(self):
 
-        self._firstIdSensNeurons = 0    # First ID of the sensory neurons (keep it at zero)
+        self._firstIdSensNeurons = (
+            0  # First ID of the sensory neurons (keep it at zero)
+        )
 
         # self._spine_param = {
         #     "wgt_motCtx_motNeur" : 1.0, # Weight motor cortex - motor neurons
@@ -336,11 +395,12 @@ class Brain():
 
 
 ####################################################################
-class MusicCfg():
+class MusicCfg:
 
     def __init__(self):
-        self._const = 1e-6 # Constant to subtract to avoid rounding errors (ms)
-        self._input_latency = 0.0001 # seconds
+        self._const = 1e-6  # Constant to subtract to avoid rounding errors (ms)
+        self._input_latency = 0.0001  # seconds
+
     @property
     def input_latency(self):
         return self._input_latency

--- a/complete_control/deprecated/simulation.py
+++ b/complete_control/deprecated/simulation.py
@@ -14,25 +14,28 @@ print(f"starting timer")
 start = timer()
 
 # Adjust env vars to be able to import the NESTML-generated module
-ld_lib_path = os.environ.get('LD_LIBRARY_PATH', '')
-new_path = ld_lib_path + ":"+"../nestml/target"
-os.environ['LD_LIBRARY_PATH'] = new_path
+ld_lib_path = os.environ.get("LD_LIBRARY_PATH", "")
+new_path = ld_lib_path + ":" + "../nestml/target"
+os.environ["LD_LIBRARY_PATH"] = new_path
 
 # Import the module
 import nest
+
 # Just to get the following imports right!
-sys.path.insert(1, '../')
+sys.path.insert(1, "../")
 
 from neural.motorcortex import MotorCortex
 from planner import Planner
 from neural.stateestimator import StateEstimator, StateEstimator_mass
-#from cerebellum import Cerebellum
+
+# from cerebellum import Cerebellum
 from population_view import plotPopulation, PopView
 
 from settings import MusicCfg, Experiment, Simulation
 import mpi4py
 from mpi4py import MPI
 import ctypes
+
 ctypes.CDLL("libmpi.so", mode=ctypes.RTLD_GLOBAL)
 import json
 from data_handling import collapse_files, add_entry
@@ -47,7 +50,7 @@ saveFig = True
 ScatterPlot = False
 
 # Opening JSON file to get parameters
-f = open('new_params.json')
+f = open("new_params.json")
 params = json.load(f)
 f.close()
 
@@ -59,8 +62,9 @@ state_se_params = params["modules"]["state_se"]
 pops_params = params["pops"]
 conn_params = params["connections"]
 
-#%%  SIMULATION
+# %%  SIMULATION
 from pathlib import Path
+
 exp = Experiment()
 sim = Simulation()
 pathFig = exp.pathFig
@@ -70,23 +74,27 @@ for root, dirs, files in os.walk(exp.pathData):
         for file in files:
             print(f"removing {file}")
             Path(os.path.join(root, file)).unlink(missing_ok=True)
-res = 0.1 #[ms]
+res = 0.1  # [ms]
 
-trj = np.loadtxt('trajectory.txt')
-motorCommands=np.loadtxt('motor_commands.txt')
+trj = np.loadtxt("trajectory.txt")
+motorCommands = np.loadtxt("motor_commands.txt")
 
 assert len(trj) == len(motorCommands)
 n_trials = sim.n_trials
-time_span = (sim.timeMax + sim.timeWait)
-time_vect  = np.linspace(0, time_span, num=int(np.round(time_span/res)), endpoint=True)
+time_span = sim.timeMax + sim.timeWait
+time_vect = np.linspace(0, time_span, num=int(np.round(time_span / res)), endpoint=True)
 
-total_time = time_span*n_trials
-total_time_vect = np.linspace(0, total_time, num=int(np.round(total_time/res)), endpoint=True)
+total_time = time_span * n_trials
+total_time_vect = np.linspace(
+    0, total_time, num=int(np.round(total_time / res)), endpoint=True
+)
 njt = 1
 
 assert len(trj) == len(total_time_vect)
-N = 50 # Number of neurons for each (sub-)population
-nTot = 2*N*njt # Total number of neurons (one positive and one negative population for each DOF)
+N = 50  # Number of neurons for each (sub-)population
+nTot = (
+    2 * N * njt
+)  # Total number of neurons (one positive and one negative population for each DOF)
 
 # nest.ResetKernel()
 nest.SetKernelStatus({"resolution": res})
@@ -94,7 +102,7 @@ nest.SetKernelStatus({"overwrite_files": True})
 nest.SetKernelStatus({"data_path": pathData})
 
 # # Cerebellum
-cereb_controlled_joint = 0 # x = 0, y = 1
+cereb_controlled_joint = 0  # x = 0, y = 1
 
 # Install the module containing neurons for planner and motor cortex
 nest.Install("controller_module")
@@ -103,138 +111,259 @@ print("init planner")
 print("--- Original Simulation Planner Init ---")
 print(f"N: {N}")
 print(f"njt: {njt}")
-print(f"total_time_vect len: {len(total_time_vect)}, start: {total_time_vect[0]:.2f}, end: {total_time_vect[-1]:.2f}, res: {res}")
+print(
+    f"total_time_vect len: {len(total_time_vect)}, start: {total_time_vect[0]:.2f}, end: {total_time_vect[-1]:.2f}, res: {res}"
+)
 print(f"trj shape: {trj.shape}, start: {trj[0]:.4f}, end: {trj[-1]:.4f}")
 print(f"pathData: {pathData}")
 print(f"plan_params['kpl']: {plan_params['kpl']}")
 print(f"plan_params['base_rate']: {plan_params['base_rate']}")
 print(f"plan_params['kp']: {plan_params['kp']}")
-planner = Planner(N, njt, total_time_vect, trj, pathData, plan_params["kpl"], plan_params["base_rate"], plan_params["kp"])
+planner = Planner(
+    N,
+    njt,
+    total_time_vect,
+    trj,
+    pathData,
+    plan_params["kpl"],
+    plan_params["base_rate"],
+    plan_params["kp"],
+)
 
 #### Motor cortex
 print("init mc")
-preciseControl = False # Precise or approximated ffwd commands?
+preciseControl = False  # Precise or approximated ffwd commands?
 print("--- Original Simulation MotorCortex Init ---")
 print(f"N: {N}")
 print(f"njt: {njt}")
-print(f"total_time_vect len: {len(total_time_vect)}, start: {total_time_vect[0]:.2f}, end: {total_time_vect[-1]:.2f}, res: {res}")
-print(f"motorCommands shape: {motorCommands.shape}, start: {motorCommands[0]:.4f}, end: {motorCommands[-1]:.4f}")
+print(
+    f"total_time_vect len: {len(total_time_vect)}, start: {total_time_vect[0]:.2f}, end: {total_time_vect[-1]:.2f}, res: {res}"
+)
+print(
+    f"motorCommands shape: {motorCommands.shape}, start: {motorCommands[0]:.4f}, end: {motorCommands[-1]:.4f}"
+)
 print(f"mc_params: {mc_params}")
 mc = MotorCortex(N, njt, total_time_vect, motorCommands, **mc_params)
 
 #### State Estimator
 print("init state")
-buf_sz = state_params['buffer_size']
-additional_state_params = {'N_fbk': N, 'N_pred': N, 'fbk_bf_size': N*int(buf_sz/res), 'pred_bf_size': N*int(buf_sz/res), 'time_wait': sim.timeWait, 'time_trial': sim.timeMax+sim.timeWait}
+buf_sz = state_params["buffer_size"]
+additional_state_params = {
+    "N_fbk": N,
+    "N_pred": N,
+    "fbk_bf_size": N * int(buf_sz / res),
+    "pred_bf_size": N * int(buf_sz / res),
+    "time_wait": sim.timeWait,
+    "time_trial": sim.timeMax + sim.timeWait,
+}
 state_params.update(additional_state_params)
 print("--- Original Simulation StateEstimator Init ---")
 print(f"N: {N}")
 print(f"njt: {njt}")
-print(f"total_time_vect len: {len(total_time_vect)}, start: {total_time_vect[0]:.2f}, end: {total_time_vect[-1]:.2f}, res: {res}")
+print(
+    f"total_time_vect len: {len(total_time_vect)}, start: {total_time_vect[0]:.2f}, end: {total_time_vect[-1]:.2f}, res: {res}"
+)
 print(f"state_params for StateEstimator_mass: {state_params}")
 stEst = StateEstimator_mass(N, njt, total_time_vect, **state_params)
 
-#%% SPINAL CORD ########################
+# %% SPINAL CORD ########################
 
-delay_fbk          = params["modules"]["spine"]["fbk_delay"]
+delay_fbk = params["modules"]["spine"]["fbk_delay"]
 wgt_sensNeur_spine = params["modules"]["spine"]["wgt_sensNeur_spine"]
 
 #### Sensory feedback (Parrot neurons on Sensory neurons)
-sn_p=[]
-sn_n=[]
+sn_p = []
+sn_n = []
 
 for j in range(njt):
     # Positive neurons
-    tmp_p = nest.Create ("parrot_neuron", N)
-    sn_p.append( PopView(tmp_p, total_time_vect, to_file=True, label="sn_p") )
+    tmp_p = nest.Create("parrot_neuron", N)
+    sn_p.append(PopView(tmp_p, total_time_vect, to_file=True, label="sn_p"))
     # Negative neurons
-    tmp_n = nest.Create ("parrot_neuron", N)
-    sn_n.append( PopView(tmp_n, total_time_vect, to_file=True, label="sn_n") )
+    tmp_n = nest.Create("parrot_neuron", N)
+    sn_n.append(PopView(tmp_n, total_time_vect, to_file=True, label="sn_n"))
 
-#%% State estimator #######
+# %% State estimator #######
 # Scale the cerebellar prediction up to 1000 Hz
 # in order to have firing rate suitable for the State estimator
 # and all the other structures inside the control system
 prediction_p = []
 prediction_n = []
 tmp_p = nest.Create("diff_neuron_nestml", N)
-nest.SetStatus(tmp_p, {"kp": pops_params["prediction"]["kp"], "pos": True, "buffer_size": pops_params["prediction"]["buffer_size"], "base_rate": pops_params["prediction"]["base_rate"], "simulation_steps": len(total_time_vect)}) #5.5
-prediction_p.append(PopView(tmp_p,total_time_vect, to_file=True, label="pred_p"))
+nest.SetStatus(
+    tmp_p,
+    {
+        "kp": pops_params["prediction"]["kp"],
+        "pos": True,
+        "buffer_size": pops_params["prediction"]["buffer_size"],
+        "base_rate": pops_params["prediction"]["base_rate"],
+        "simulation_steps": len(total_time_vect),
+    },
+)  # 5.5
+prediction_p.append(PopView(tmp_p, total_time_vect, to_file=True, label="pred_p"))
 tmp_n = nest.Create("diff_neuron_nestml", N)
-nest.SetStatus(tmp_n, {"kp": pops_params["prediction"]["kp"], "pos": False, "buffer_size": pops_params["prediction"]["buffer_size"], "base_rate": pops_params["prediction"]["base_rate"], "simulation_steps": len(total_time_vect)}) #5.5
-prediction_n.append(PopView(tmp_n,total_time_vect, to_file=True, label="pred_n"))
+nest.SetStatus(
+    tmp_n,
+    {
+        "kp": pops_params["prediction"]["kp"],
+        "pos": False,
+        "buffer_size": pops_params["prediction"]["buffer_size"],
+        "base_rate": pops_params["prediction"]["base_rate"],
+        "simulation_steps": len(total_time_vect),
+    },
+)  # 5.5
+prediction_n.append(PopView(tmp_n, total_time_vect, to_file=True, label="pred_n"))
 
 wgt_fbk_sm_state = params["connections"]["fbk_smoothed_state"]["weight"]
 
 
 for j in range(njt):
-    ''
+    """"""
     if j == cereb_controlled_joint:
         # Modify variability sensory feedback ("smoothed")
         fbk_smoothed_p = nest.Create("basic_neuron_nestml", N)
-        nest.SetStatus(fbk_smoothed_p, {"kp": pops_params["fbk_smoothed"]["kp"], "pos": True, "buffer_size": pops_params["fbk_smoothed"]["buffer_size"], "base_rate": pops_params["fbk_smoothed"]["base_rate"], "simulation_steps": len(total_time_vect)})
+        nest.SetStatus(
+            fbk_smoothed_p,
+            {
+                "kp": pops_params["fbk_smoothed"]["kp"],
+                "pos": True,
+                "buffer_size": pops_params["fbk_smoothed"]["buffer_size"],
+                "base_rate": pops_params["fbk_smoothed"]["base_rate"],
+                "simulation_steps": len(total_time_vect),
+            },
+        )
         fbk_smoothed_n = nest.Create("basic_neuron_nestml", N)
-        nest.SetStatus(fbk_smoothed_n, {"kp": pops_params["fbk_smoothed"]["kp"], "pos": False, "buffer_size": pops_params["fbk_smoothed"]["buffer_size"], "base_rate": pops_params["fbk_smoothed"]["base_rate"], "simulation_steps": len(total_time_vect)})
-        
-        nest.Connect(sn_p[j].pop, fbk_smoothed_p, "all_to_all", syn_spec={"weight": conn_params["sn_fbk_smoothed"]["weight"], "delay": conn_params["sn_fbk_smoothed"]["delay"]})
+        nest.SetStatus(
+            fbk_smoothed_n,
+            {
+                "kp": pops_params["fbk_smoothed"]["kp"],
+                "pos": False,
+                "buffer_size": pops_params["fbk_smoothed"]["buffer_size"],
+                "base_rate": pops_params["fbk_smoothed"]["base_rate"],
+                "simulation_steps": len(total_time_vect),
+            },
+        )
 
-        nest.Connect(sn_n[j].pop, fbk_smoothed_n, "all_to_all", syn_spec={"weight": -conn_params["sn_fbk_smoothed"]["weight"], "delay": conn_params["sn_fbk_smoothed"]["delay"]})
+        nest.Connect(
+            sn_p[j].pop,
+            fbk_smoothed_p,
+            "all_to_all",
+            syn_spec={
+                "weight": conn_params["sn_fbk_smoothed"]["weight"],
+                "delay": conn_params["sn_fbk_smoothed"]["delay"],
+            },
+        )
+
+        nest.Connect(
+            sn_n[j].pop,
+            fbk_smoothed_n,
+            "all_to_all",
+            syn_spec={
+                "weight": -conn_params["sn_fbk_smoothed"]["weight"],
+                "delay": conn_params["sn_fbk_smoothed"]["delay"],
+            },
+        )
 
         # Positive neurons
         for i, pre in enumerate(fbk_smoothed_p):
             for k, post in enumerate(stEst.pops_p[j].pop):
-                nest.Connect(pre, post, "one_to_one", syn_spec = {"weight": wgt_fbk_sm_state, "receptor_type": i + 1})
+                nest.Connect(
+                    pre,
+                    post,
+                    "one_to_one",
+                    syn_spec={"weight": wgt_fbk_sm_state, "receptor_type": i + 1},
+                )
 
         for i, pre in enumerate(prediction_p[0].pop):
             for k, post in enumerate(stEst.pops_p[j].pop):
-                nest.Connect(pre, post, "one_to_one", syn_spec = {"weight": 1.0, "receptor_type": i + 1 + N})
-        
+                nest.Connect(
+                    pre,
+                    post,
+                    "one_to_one",
+                    syn_spec={"weight": 1.0, "receptor_type": i + 1 + N},
+                )
 
         # Negative neurons
         for i, pre in enumerate(fbk_smoothed_n):
             for k, post in enumerate(stEst.pops_n[j].pop):
-                nest.Connect(pre, post, "one_to_one", syn_spec = {"weight": wgt_fbk_sm_state, "receptor_type": i + 1})
+                nest.Connect(
+                    pre,
+                    post,
+                    "one_to_one",
+                    syn_spec={"weight": wgt_fbk_sm_state, "receptor_type": i + 1},
+                )
 
         for i, pre in enumerate(prediction_n[0].pop):
             for k, post in enumerate(stEst.pops_n[j].pop):
-                nest.Connect(pre, post, "one_to_one", syn_spec = {"weight": 1.0, "receptor_type": i + 1 + N})
+                nest.Connect(
+                    pre,
+                    post,
+                    "one_to_one",
+                    syn_spec={"weight": 1.0, "receptor_type": i + 1 + N},
+                )
     else:
 
         # Positive neurons
-        #nest.Connect(sn_p[j].pop, stEst.pops_p[j].pop, "all_to_all", syn_spec=conn_params["sn_state"])
+        # nest.Connect(sn_p[j].pop, stEst.pops_p[j].pop, "all_to_all", syn_spec=conn_params["sn_state"])
         for i, pre in enumerate(sn_p[j].pop):
             for k, post in enumerate(stEst.pops_p[j].pop):
-                nest.Connect(pre, post, "one_to_one", syn_spec = {"weight": conn_params["sn_state"]["weight"], "receptor_type": i + 1})
+                nest.Connect(
+                    pre,
+                    post,
+                    "one_to_one",
+                    syn_spec={
+                        "weight": conn_params["sn_state"]["weight"],
+                        "receptor_type": i + 1,
+                    },
+                )
         # Negative neurons
-        
+
         for i, pre in enumerate(sn_n[j].pop):
             for k, post in enumerate(stEst.pops_n[j].pop):
-                nest.Connect(pre, post, "one_to_one", syn_spec = {"weight": conn_params["sn_state"]["weight"], "receptor_type": i + 1})
+                nest.Connect(
+                    pre,
+                    post,
+                    "one_to_one",
+                    syn_spec={
+                        "weight": conn_params["sn_state"]["weight"],
+                        "receptor_type": i + 1,
+                    },
+                )
 
 print("init connections feedback")
-'''
+"""
 #%% CONNECTIONS
-'''
+"""
 #### Connection Planner - Motor Cortex feedback (excitatory)
-wgt_plnr_mtxFbk   = conn_params["planner_mc_fbk"]["weight"]
+wgt_plnr_mtxFbk = conn_params["planner_mc_fbk"]["weight"]
 
 
 # Delay between planner and motor cortex feedback.
 # It needs to compensate for the delay introduced by the state estimator
-#delay_plnr_mtxFbk = brain.stEst_param["buf_sz"] # USE THIS WITH REAL STATE ESTIMATOR
-delay_plnr_mtxFbk = conn_params["planner_mc_fbk"]["delay"]                         # USE THIS WITH "FAKE" STATE ESTIMATOR
+# delay_plnr_mtxFbk = brain.stEst_param["buf_sz"] # USE THIS WITH REAL STATE ESTIMATOR
+delay_plnr_mtxFbk = conn_params["planner_mc_fbk"][
+    "delay"
+]  # USE THIS WITH "FAKE" STATE ESTIMATOR
 
 for j in range(njt):
-    planner.pops_p[j].connect( mc.fbk_p[j], rule='one_to_one', w= wgt_plnr_mtxFbk, d=delay_plnr_mtxFbk )
-    planner.pops_p[j].connect( mc.fbk_n[j], rule='one_to_one', w= wgt_plnr_mtxFbk, d=delay_plnr_mtxFbk )
-    planner.pops_n[j].connect( mc.fbk_p[j], rule='one_to_one', w=-wgt_plnr_mtxFbk, d=delay_plnr_mtxFbk )
-    planner.pops_n[j].connect( mc.fbk_n[j], rule='one_to_one', w=-wgt_plnr_mtxFbk, d=delay_plnr_mtxFbk )
+    planner.pops_p[j].connect(
+        mc.fbk_p[j], rule="one_to_one", w=wgt_plnr_mtxFbk, d=delay_plnr_mtxFbk
+    )
+    planner.pops_p[j].connect(
+        mc.fbk_n[j], rule="one_to_one", w=wgt_plnr_mtxFbk, d=delay_plnr_mtxFbk
+    )
+    planner.pops_n[j].connect(
+        mc.fbk_p[j], rule="one_to_one", w=-wgt_plnr_mtxFbk, d=delay_plnr_mtxFbk
+    )
+    planner.pops_n[j].connect(
+        mc.fbk_n[j], rule="one_to_one", w=-wgt_plnr_mtxFbk, d=delay_plnr_mtxFbk
+    )
 
 #### Connection State Estimator - Motor Cortex feedback (Inhibitory)
 wgt_stEst_mtxFbk = conn_params["state_mc_fbk"]["weight"]
 
 
-'''
+"""
 nest.Connect(mc.out_p[cereb_controlled_joint].pop, motor_commands_p, "all_to_all", syn_spec={"weight": conn_params["mc_out_motor_commands"]["weight"], "delay": conn_params["mc_out_motor_commands"]["delay"]})
 nest.Connect(mc.out_n[cereb_controlled_joint].pop, motor_commands_n, "all_to_all", syn_spec={"weight": -conn_params["mc_out_motor_commands"]["weight"], "delay": conn_params["mc_out_motor_commands"]["delay"]})
 ''
@@ -249,66 +378,124 @@ nest.SetStatus(feedback_n, {"kp": pops_params["feedback"]["kp"], "pos": False, "
 
 nest.Connect(sn_p[cereb_controlled_joint].pop, feedback_p, 'all_to_all', syn_spec={"weight": conn_params["sn_fbk_smoothed"]["weight"], "delay": conn_params["sn_fbk_smoothed"]["delay"]})
 nest.Connect(sn_n[cereb_controlled_joint].pop, feedback_n, 'all_to_all', syn_spec={"weight": -conn_params["sn_fbk_smoothed"]["weight"], "delay": conn_params["sn_fbk_smoothed"]["delay"]})
-'''
+"""
 
 # Connect state estimator (bayesian) to the Motor Cortex
 for j in range(njt):
-    nest.Connect(stEst.pops_p[j].pop,mc.fbk_p[j].pop, "one_to_one", {"weight": wgt_stEst_mtxFbk, "delay": res})
-    nest.Connect(stEst.pops_p[j].pop,mc.fbk_n[j].pop, "one_to_one", {"weight": wgt_stEst_mtxFbk, "delay": res})
-    nest.Connect(stEst.pops_n[j].pop,mc.fbk_p[j].pop, "one_to_one", {"weight": -wgt_stEst_mtxFbk, "delay": res})
-    nest.Connect(stEst.pops_n[j].pop,mc.fbk_n[j].pop, "one_to_one", {"weight": -wgt_stEst_mtxFbk, "delay": res})
+    nest.Connect(
+        stEst.pops_p[j].pop,
+        mc.fbk_p[j].pop,
+        "one_to_one",
+        {"weight": wgt_stEst_mtxFbk, "delay": res},
+    )
+    nest.Connect(
+        stEst.pops_p[j].pop,
+        mc.fbk_n[j].pop,
+        "one_to_one",
+        {"weight": wgt_stEst_mtxFbk, "delay": res},
+    )
+    nest.Connect(
+        stEst.pops_n[j].pop,
+        mc.fbk_p[j].pop,
+        "one_to_one",
+        {"weight": -wgt_stEst_mtxFbk, "delay": res},
+    )
+    nest.Connect(
+        stEst.pops_n[j].pop,
+        mc.fbk_n[j].pop,
+        "one_to_one",
+        {"weight": -wgt_stEst_mtxFbk, "delay": res},
+    )
 
 # BRAIN STEM
-brain_stem_new_p=[]
-brain_stem_new_n=[]
+brain_stem_new_p = []
+brain_stem_new_n = []
 
 
 for j in range(njt):
     # Positive neurons
-    tmp_p = nest.Create ("basic_neuron_nestml", N)
-    nest.SetStatus(tmp_p, {"kp": pops_params["brain_stem"]["kp"], "pos": True, "buffer_size": pops_params["brain_stem"]["buffer_size"], "base_rate": pops_params["brain_stem"]["base_rate"], "simulation_steps": len(total_time_vect)})
-    brain_stem_new_p.append( PopView(tmp_p, total_time_vect, to_file=True, label="brainstem_p") )
+    tmp_p = nest.Create("basic_neuron_nestml", N)
+    nest.SetStatus(
+        tmp_p,
+        {
+            "kp": pops_params["brain_stem"]["kp"],
+            "pos": True,
+            "buffer_size": pops_params["brain_stem"]["buffer_size"],
+            "base_rate": pops_params["brain_stem"]["base_rate"],
+            "simulation_steps": len(total_time_vect),
+        },
+    )
+    brain_stem_new_p.append(
+        PopView(tmp_p, total_time_vect, to_file=True, label="brainstem_p")
+    )
     # Negative neurons
-    tmp_n = nest.Create ("basic_neuron_nestml", N)
-    nest.SetStatus(tmp_n, {"kp": pops_params["brain_stem"]["kp"], "pos": False, "buffer_size": pops_params["brain_stem"]["buffer_size"], "base_rate": pops_params["brain_stem"]["base_rate"], "simulation_steps": len(total_time_vect)})
-    brain_stem_new_n.append( PopView(tmp_n, total_time_vect, to_file=True, label="brainstem_n") )
+    tmp_n = nest.Create("basic_neuron_nestml", N)
+    nest.SetStatus(
+        tmp_n,
+        {
+            "kp": pops_params["brain_stem"]["kp"],
+            "pos": False,
+            "buffer_size": pops_params["brain_stem"]["buffer_size"],
+            "base_rate": pops_params["brain_stem"]["base_rate"],
+            "simulation_steps": len(total_time_vect),
+        },
+    )
+    brain_stem_new_n.append(
+        PopView(tmp_n, total_time_vect, to_file=True, label="brainstem_n")
+    )
 
 
 for j in range(njt):
-    nest.Connect(mc.out_p[j].pop,brain_stem_new_p[j].pop, "all_to_all", {"weight": conn_params["mc_out_brain_stem"]["weight"], "delay": conn_params["mc_out_brain_stem"]["delay"]})
+    nest.Connect(
+        mc.out_p[j].pop,
+        brain_stem_new_p[j].pop,
+        "all_to_all",
+        {
+            "weight": conn_params["mc_out_brain_stem"]["weight"],
+            "delay": conn_params["mc_out_brain_stem"]["delay"],
+        },
+    )
     # nest.Connect(stEst.pops_p[j].pop,mc.fbk_n[j].pop, "one_to_one", {"weight": wgt_stEst_mtxFbk, "delay": res})
     # nest.Connect(stEst.pops_n[j].pop,mc.fbk_p[j].pop, "one_to_one", {"weight": -wgt_stEst_mtxFbk, "delay": res})
-    nest.Connect(mc.out_n[j].pop,brain_stem_new_n[j].pop, "all_to_all", {"weight": -conn_params["mc_out_brain_stem"]["weight"], "delay": conn_params["mc_out_brain_stem"]["delay"]})
+    nest.Connect(
+        mc.out_n[j].pop,
+        brain_stem_new_n[j].pop,
+        "all_to_all",
+        {
+            "weight": -conn_params["mc_out_brain_stem"]["weight"],
+            "delay": conn_params["mc_out_brain_stem"]["delay"],
+        },
+    )
 
-'''
+"""
 # feedback from sensory
 feedback_inv_p = nest.Create("diff_neuron", N)
 nest.SetStatus(feedback_inv_p, {"kp": pops_params["feedback_inv"]["kp"], "pos": True, "buffer_size": pops_params["feedback_inv"]["buffer_size"], "base_rate": pops_params["feedback_inv"]["base_rate"]})
 feedback_inv_n = nest.Create("diff_neuron", N)
 nest.SetStatus(feedback_inv_n, {"kp": pops_params["feedback_inv"]["kp"], "pos": False, "buffer_size": pops_params["feedback_inv"]["buffer_size"], "base_rate": pops_params["feedback_inv"]["base_rate"]})
-'''
+"""
 
-#%% MUSIC CONFIG
+# %% MUSIC CONFIG
 
 msc = MusicCfg()
 
 #### MUSIC output port (with nTot channels)
-proxy_out = nest.Create('music_event_out_proxy', 1, params = {'port_name':'mot_cmd_out'})
+proxy_out = nest.Create("music_event_out_proxy", 1, params={"port_name": "mot_cmd_out"})
 
-ii=0
+ii = 0
 for j in range(njt):
     for i, n in enumerate(brain_stem_new_p[j].pop):
-        nest.Connect(n, proxy_out, "one_to_one",{'music_channel': ii})
-        ii=ii+1
+        nest.Connect(n, proxy_out, "one_to_one", {"music_channel": ii})
+        ii = ii + 1
     for i, n in enumerate(brain_stem_new_n[j].pop):
-        nest.Connect(n, proxy_out, "one_to_one",{'music_channel': ii})
-        ii=ii+1
+        nest.Connect(n, proxy_out, "one_to_one", {"music_channel": ii})
+        ii = ii + 1
 
 
 #### MUSIC input ports (nTot ports with one channel each)
-proxy_in = nest.Create ('music_event_in_proxy', nTot, params = {'port_name': 'fbk_in'})
+proxy_in = nest.Create("music_event_in_proxy", nTot, params={"port_name": "fbk_in"})
 for i, n in enumerate(proxy_in):
-    nest.SetStatus(n, {'music_channel': i})
+    nest.SetStatus(n, {"music_channel": i})
 
 # Divide channels based on function (using channel order)
 for j in range(njt):
@@ -319,24 +506,34 @@ for j in range(njt):
         delay = 0.1
 
     #### Positive channels
-    idxSt_p = 2*N*j
+    idxSt_p = 2 * N * j
     idxEd_p = idxSt_p + N
-    nest.Connect( proxy_in[idxSt_p:idxEd_p], sn_p[j].pop, 'one_to_one', {"weight":wgt_sensNeur_spine, "delay":delay} )
+    nest.Connect(
+        proxy_in[idxSt_p:idxEd_p],
+        sn_p[j].pop,
+        "one_to_one",
+        {"weight": wgt_sensNeur_spine, "delay": delay},
+    )
     #### Negative channels
     idxSt_n = idxEd_p
     idxEd_n = idxSt_n + N
-    nest.Connect( proxy_in[idxSt_n:idxEd_n], sn_n[j].pop, 'one_to_one', {"weight":wgt_sensNeur_spine, "delay":delay} )
+    nest.Connect(
+        proxy_in[idxSt_n:idxEd_n],
+        sn_n[j].pop,
+        "one_to_one",
+        {"weight": wgt_sensNeur_spine, "delay": delay},
+    )
 
 # We need to tell MUSIC, through NEST, that it's OK (due to the delay)
 # to deliver spikes a bit late. This is what makes the loop possible.
-nest.SetAcceptableLatency('fbk_in', 0.1-msc.const)
+nest.SetAcceptableLatency("fbk_in", 0.1 - msc.const)
 
 ###################### Extra Spikedetectors ######################
 
 spikedetector_fbk_pos = nest.Create("spike_recorder", params={"label": "Feedback pos"})
 spikedetector_fbk_neg = nest.Create("spike_recorder", params={"label": "Feedback neg"})
 
-'''
+"""
 spikedetector_fbk_inv_pos = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Feedback inv pos"})
 spikedetector_fbk_inv_neg = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Feedback inv neg"})
 
@@ -347,24 +544,40 @@ spikedetector_io_forw_input_neg = nest.Create("spike_recorder", params={"withgid
 
 spikedetector_io_inv_input_pos = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Input inferior Olive Inv pos"})
 spikedetector_io_inv_input_neg = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Input inferior Olive Inv neg"})
-'''
-spikedetector_stEst_pos = nest.Create("spike_recorder", params={"label": "State estimator pos"})
-spikedetector_stEst_neg = nest.Create("spike_recorder", params={"label": "State estimator neg"})
+"""
+spikedetector_stEst_pos = nest.Create(
+    "spike_recorder", params={"label": "State estimator pos"}
+)
+spikedetector_stEst_neg = nest.Create(
+    "spike_recorder", params={"label": "State estimator neg"}
+)
 
-spikedetector_planner_pos = nest.Create("spike_recorder", params={"label": "Planner pos"})
-spikedetector_planner_neg = nest.Create("spike_recorder", params={"label": "Planner neg"})
+spikedetector_planner_pos = nest.Create(
+    "spike_recorder", params={"label": "Planner pos"}
+)
+spikedetector_planner_neg = nest.Create(
+    "spike_recorder", params={"label": "Planner neg"}
+)
 
-#spikedetector_pred_pos = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Cereb pred pos"})
-#spikedetector_pred_neg = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Cereb pred neg"})
-#spikedetector_motor_pred_pos = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Cereb motor pred pos"})
-#spikedetector_motor_pred_neg = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Cereb motor pred neg"})
-#spikedetector_stEst_max_pos = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "State estimator Max pos"})
-#spikedetector_stEst_max_neg = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "State estimator Max neg"})
-spikedetector_fbk_smoothed_pos = nest.Create("spike_recorder", params={"label": "Feedback smoothed pos"})
-spikedetector_fbk_smoothed_neg = nest.Create("spike_recorder", params={"label": "Feedback smoothed neg"})
+# spikedetector_pred_pos = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Cereb pred pos"})
+# spikedetector_pred_neg = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Cereb pred neg"})
+# spikedetector_motor_pred_pos = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Cereb motor pred pos"})
+# spikedetector_motor_pred_neg = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "Cereb motor pred neg"})
+# spikedetector_stEst_max_pos = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "State estimator Max pos"})
+# spikedetector_stEst_max_neg = nest.Create("spike_recorder", params={"withgid": True,"withtime": True, "to_file": True, "label": "State estimator Max neg"})
+spikedetector_fbk_smoothed_pos = nest.Create(
+    "spike_recorder", params={"label": "Feedback smoothed pos"}
+)
+spikedetector_fbk_smoothed_neg = nest.Create(
+    "spike_recorder", params={"label": "Feedback smoothed neg"}
+)
 
-spikedetector_brain_stem_pos = nest.Create("spike_recorder", params={"label": "Brain stem pos"})
-spikedetector_brain_stem_neg = nest.Create("spike_recorder", params={"label": "Brain stem neg"})
+spikedetector_brain_stem_pos = nest.Create(
+    "spike_recorder", params={"label": "Brain stem pos"}
+)
+spikedetector_brain_stem_neg = nest.Create(
+    "spike_recorder", params={"label": "Brain stem neg"}
+)
 
 nest.Connect(brain_stem_new_p[j].pop, spikedetector_brain_stem_pos)
 nest.Connect(brain_stem_new_n[j].pop, spikedetector_brain_stem_neg)
@@ -374,19 +587,19 @@ nest.Connect(fbk_smoothed_p, spikedetector_fbk_smoothed_pos)
 
 nest.Connect(sn_p[cereb_controlled_joint].pop, spikedetector_fbk_pos)
 nest.Connect(sn_n[cereb_controlled_joint].pop, spikedetector_fbk_neg)
-#nest.Connect(feedback_p, spikedetector_fbk_cereb_pos)
-#nest.Connect(feedback_n, spikedetector_fbk_cereb_neg)
+# nest.Connect(feedback_p, spikedetector_fbk_cereb_pos)
+# nest.Connect(feedback_n, spikedetector_fbk_cereb_neg)
 
 nest.Connect(planner.pops_p[cereb_controlled_joint].pop, spikedetector_planner_pos)
 nest.Connect(planner.pops_n[cereb_controlled_joint].pop, spikedetector_planner_neg)
-'''
+"""
 nest.Connect(stEst.pops_p[cereb_controlled_joint].pop, spikedetector_stEst_max_pos)
 nest.Connect(stEst.pops_n[cereb_controlled_joint].pop, spikedetector_stEst_max_neg)
-'''
+"""
 
 
 ###################### SIMULATE ######################
-'''
+"""
 # Disable Cerebellar prediction in State estimation 
 conns_pos_forw = nest.GetConnections(source = prediction_p, target = stEst.pops_p[cereb_controlled_joint].pop)
 conns_neg_forw = nest.GetConnections(source = prediction_n, target = stEst.pops_n[cereb_controlled_joint].pop)
@@ -395,15 +608,32 @@ conns_neg_forw = nest.GetConnections(source = prediction_n, target = stEst.pops_
 if cerebellum_application_forw != 0:
     nest.SetStatus(conns_pos_forw, {"weight": 0.0})
     nest.SetStatus(conns_neg_forw, {"weight": 0.0})
-'''
+"""
 
 time_network = timedelta(seconds=timer() - start)
 
-#%% SIMULATE ######################
-#nest.SetKernelStatus({"data_path": pthDat})
-#total_len = int(time_span + time_pause)
+# %% SIMULATE ######################
+# nest.SetKernelStatus({"data_path": pthDat})
+# total_len = int(time_span + time_pause)
 names = exp.names
-pops = [planner.pops_p, planner.pops_n, mc.ffwd_p, mc.ffwd_n, mc.fbk_p, mc.fbk_n, mc.out_p, mc.out_n, brain_stem_new_p, brain_stem_new_n, sn_p, sn_n, prediction_p, prediction_n, stEst.pops_p, stEst.pops_n]
+pops = [
+    planner.pops_p,
+    planner.pops_n,
+    mc.ffwd_p,
+    mc.ffwd_n,
+    mc.fbk_p,
+    mc.fbk_n,
+    mc.out_p,
+    mc.out_n,
+    brain_stem_new_p,
+    brain_stem_new_n,
+    sn_p,
+    sn_n,
+    prediction_p,
+    prediction_n,
+    stEst.pops_p,
+    stEst.pops_n,
+]
 
 total_len = int(time_span)
 
@@ -412,7 +642,7 @@ print(nest.GetNodes())
 
 for trial in range(n_trials):
     if mpi4py.MPI.COMM_WORLD.rank == 0:
-        print('Simulating trial {} lasting {} ms'.format(trial+1,total_len))
+        print("Simulating trial {} lasting {} ms".format(trial + 1, total_len))
     nest.Simulate(total_len)
     collapse_files(pathData, names, pops, njt)
 events_orig = nest.GetStatus(spikedetector_fbk_smoothed_pos, "events")[0]
@@ -423,142 +653,222 @@ print(f"Num spikes: {len(times_orig)}")
 if len(times_orig) > 0:
     print(f"First spike time: {times_orig[0]}, sender: {senders_orig[0]}")
     print(f"Last spike time: {times_orig[-1]}, sender: {senders_orig[-1]}")
-'''
+"""
 if mpi4py.MPI.COMM_WORLD.rank == 0:
     choice = input("Save?")
     if choice == 'y':
         add_entry(exp)
-'''
+"""
 
 # Gather data
 
 
-#add_entry(exp)
+# add_entry(exp)
 
 
-#%% PLOTTING
+# %% PLOTTING
 # Figure per la presentazione
 # Planner + trajectory
 if mpi4py.MPI.COMM_WORLD.rank == 0:
-    lgd = ['theta']
-    #time_vect_paused = np.linspace(0, total_len*n_trial, num=int(np.round(total_len/res)), endpoint=True)
+    lgd = ["theta"]
+    # time_vect_paused = np.linspace(0, total_len*n_trial, num=int(np.round(total_len/res)), endpoint=True)
     time_vect_paused = total_time_vect
-    print('planner')
-    reference =[trj]
-    legend = ['trajectory']
-    styles=['k']
-    time_vecs=[time_vect_paused]
+    print("planner")
+    reference = [trj]
+    legend = ["trajectory"]
+    styles = ["k"]
+    time_vecs = [time_vect_paused]
     for i in range(njt):
-            plotPopulation(time_vect_paused, planner.pops_p[i],planner.pops_n[i], reference, time_vecs,legend, styles, title=lgd[i],buffer_size=15)
-            plt.suptitle("Planner")
-            if saveFig:
-                #plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/planner_"+lgd[i]+".png")
-                plt.savefig(pathFig+"planner_"+lgd[i]+".png")
-    reference =[motorCommands]
-    legend = ['motor commands']
+        plotPopulation(
+            time_vect_paused,
+            planner.pops_p[i],
+            planner.pops_n[i],
+            reference,
+            time_vecs,
+            legend,
+            styles,
+            title=lgd[i],
+            buffer_size=15,
+        )
+        plt.suptitle("Planner")
+        if saveFig:
+            # plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/planner_"+lgd[i]+".png")
+            plt.savefig(pathFig + "planner_" + lgd[i] + ".png")
+    reference = [motorCommands]
+    legend = ["motor commands"]
 
-    print('mc ffwd')
+    print("mc ffwd")
     for i in range(njt):
-            plotPopulation(time_vect_paused, mc.ffwd_p[i],mc.ffwd_n[i], reference, time_vecs,legend, styles,title=lgd[i],buffer_size=15)
-            plt.suptitle("Mc ffwd")
-            if saveFig:
-                #plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/mc_ffwd_"+lgd[i]+".png")
-                plt.savefig(pathFig+"mc_ffwd_"+lgd[i]+".png")
-    
-    
-    bins_p,count_p,rate_p = planner.pops_p[0].computePSTH(time_vect_paused, 15)
-    bins_n,count_n,rate_n = planner.pops_n[0].computePSTH(time_vect_paused, 15)
-    bins_stEst_p,count_stEst_p,rate_stEst_p = stEst.pops_p[0].computePSTH(time_vect_paused, 15)
-    bins_stEst_n,count_stEst_n,rate_stEst_n = stEst.pops_n[0].computePSTH(time_vect_paused, 15)
+        plotPopulation(
+            time_vect_paused,
+            mc.ffwd_p[i],
+            mc.ffwd_n[i],
+            reference,
+            time_vecs,
+            legend,
+            styles,
+            title=lgd[i],
+            buffer_size=15,
+        )
+        plt.suptitle("Mc ffwd")
+        if saveFig:
+            # plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/mc_ffwd_"+lgd[i]+".png")
+            plt.savefig(pathFig + "mc_ffwd_" + lgd[i] + ".png")
 
-    print('mc fbk')
-    reference =[rate_p-rate_stEst_p, rate_n - rate_stEst_n]
+    bins_p, count_p, rate_p = planner.pops_p[0].computePSTH(time_vect_paused, 15)
+    bins_n, count_n, rate_n = planner.pops_n[0].computePSTH(time_vect_paused, 15)
+    bins_stEst_p, count_stEst_p, rate_stEst_p = stEst.pops_p[0].computePSTH(
+        time_vect_paused, 15
+    )
+    bins_stEst_n, count_stEst_n, rate_stEst_n = stEst.pops_n[0].computePSTH(
+        time_vect_paused, 15
+    )
+
+    print("mc fbk")
+    reference = [rate_p - rate_stEst_p, rate_n - rate_stEst_n]
     time_vecs = [bins_p[:-1], bins_n[:-1]]
-    legend = ['diff_p', 'diff_n']
-    styles = ['r--', 'b--']
+    legend = ["diff_p", "diff_n"]
+    styles = ["r--", "b--"]
     for i in range(njt):
-            plotPopulation(time_vect_paused, mc.fbk_p[i],mc.fbk_n[i], reference, time_vecs, legend, styles,title=lgd[i],buffer_size=15)
-            plt.suptitle("Mc fbk")
-            if saveFig:
-                #plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/mc_fbk_"+lgd[i]+".png")
-                plt.savefig(pathFig+"mc_fbk_"+lgd[i]+".png")
+        plotPopulation(
+            time_vect_paused,
+            mc.fbk_p[i],
+            mc.fbk_n[i],
+            reference,
+            time_vecs,
+            legend,
+            styles,
+            title=lgd[i],
+            buffer_size=15,
+        )
+        plt.suptitle("Mc fbk")
+        if saveFig:
+            # plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/mc_fbk_"+lgd[i]+".png")
+            plt.savefig(pathFig + "mc_fbk_" + lgd[i] + ".png")
 
-    bins_p,count_p,rate_p = mc.ffwd_p[0].computePSTH(time_vect_paused, 15)
-    bins_n,count_n,rate_n = mc.ffwd_n[0].computePSTH(time_vect_paused, 15)
-    bins_fbk_p,count_fbk_p,rate_fbk_p = mc.fbk_p[0].computePSTH(time_vect_paused, 15)
-    bins_fbk_n,count_fbk_n,rate_fbk_n = mc.fbk_n[0].computePSTH(time_vect_paused, 15)
-    print('mc out')
-    reference =[rate_p+rate_fbk_p, rate_n + rate_fbk_n]
+    bins_p, count_p, rate_p = mc.ffwd_p[0].computePSTH(time_vect_paused, 15)
+    bins_n, count_n, rate_n = mc.ffwd_n[0].computePSTH(time_vect_paused, 15)
+    bins_fbk_p, count_fbk_p, rate_fbk_p = mc.fbk_p[0].computePSTH(time_vect_paused, 15)
+    bins_fbk_n, count_fbk_n, rate_fbk_n = mc.fbk_n[0].computePSTH(time_vect_paused, 15)
+    print("mc out")
+    reference = [rate_p + rate_fbk_p, rate_n + rate_fbk_n]
     time_vecs = [bins_p[:-1], bins_n[:-1]]
-    legend = ['sum_p', 'sum_n']
-    styles = ['r--', 'b--']
+    legend = ["sum_p", "sum_n"]
+    styles = ["r--", "b--"]
     for i in range(njt):
-            plotPopulation(time_vect_paused, mc.out_p[i],mc.out_n[i], reference, time_vecs, legend, styles,title=lgd[i],buffer_size=15)
-            plt.suptitle("Mc out")
-            if saveFig:
-                #plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/mc_out_"+lgd[i]+".png")
-                plt.savefig(pathFig+"mc_out_"+lgd[i]+".png")
+        plotPopulation(
+            time_vect_paused,
+            mc.out_p[i],
+            mc.out_n[i],
+            reference,
+            time_vecs,
+            legend,
+            styles,
+            title=lgd[i],
+            buffer_size=15,
+        )
+        plt.suptitle("Mc out")
+        if saveFig:
+            # plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/mc_out_"+lgd[i]+".png")
+            plt.savefig(pathFig + "mc_out_" + lgd[i] + ".png")
 
-    bins_p,count_p,rate_p = mc.out_p[0].computePSTH(time_vect_paused, 15)
-    bins_n,count_n,rate_n = mc.out_n[0].computePSTH(time_vect_paused, 15)
+    bins_p, count_p, rate_p = mc.out_p[0].computePSTH(time_vect_paused, 15)
+    bins_n, count_n, rate_n = mc.out_n[0].computePSTH(time_vect_paused, 15)
 
-    reference =[rate_p, rate_n]
+    reference = [rate_p, rate_n]
     time_vecs = [bins_p[:-1], bins_n[:-1]]
-    legend = ['out_p', 'out_n']
-    styles = ['r', 'b']
-    print('brainstem')
+    legend = ["out_p", "out_n"]
+    styles = ["r", "b"]
+    print("brainstem")
     for i in range(njt):
-            plotPopulation(time_vect_paused, brain_stem_new_p[i],brain_stem_new_n[i], reference, time_vecs, legend, styles,title=lgd[i],buffer_size=15)
-            plt.suptitle("Brainstem")
-            if saveFig:
-                #plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/brainstem_"+lgd[i]+".png")
-                plt.savefig(pathFig+"brainstem_"+lgd[i]+".png")
+        plotPopulation(
+            time_vect_paused,
+            brain_stem_new_p[i],
+            brain_stem_new_n[i],
+            reference,
+            time_vecs,
+            legend,
+            styles,
+            title=lgd[i],
+            buffer_size=15,
+        )
+        plt.suptitle("Brainstem")
+        if saveFig:
+            # plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/brainstem_"+lgd[i]+".png")
+            plt.savefig(pathFig + "brainstem_" + lgd[i] + ".png")
 
-    reference =[]
+    reference = []
     time_vecs = []
     legend = []
     styles = []
-    print('sensory')
-    print('prova: ', sn_n[i].total_ts)
+    print("sensory")
+    print("prova: ", sn_n[i].total_ts)
     for i in range(njt):
-            plotPopulation(time_vect_paused, sn_p[i],sn_n[i], reference, time_vecs, legend, styles,buffer_size=15)
-            plt.suptitle("Sensory")
-            if saveFig:
-                #plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/sensory_"+lgd[i]+".png")
-                plt.savefig(pathFig+"sensory_"+lgd[i]+".png")
+        plotPopulation(
+            time_vect_paused,
+            sn_p[i],
+            sn_n[i],
+            reference,
+            time_vecs,
+            legend,
+            styles,
+            buffer_size=15,
+        )
+        plt.suptitle("Sensory")
+        if saveFig:
+            # plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/sensory_"+lgd[i]+".png")
+            plt.savefig(pathFig + "sensory_" + lgd[i] + ".png")
 
-    bins_p,count_p,rate_p = sn_p[0].computePSTH(time_vect_paused, 15)
-    bins_n,count_n,rate_n = sn_n[0].computePSTH(time_vect_paused, 15)
-    bins_pred_p,count_pred_p,rate_pred_p = prediction_p[0].computePSTH(time_vect_paused, 15)
-    bins_pred_n,count_pred_n,rate_pred_n = prediction_n[0].computePSTH(time_vect_paused, 15)
+    bins_p, count_p, rate_p = sn_p[0].computePSTH(time_vect_paused, 15)
+    bins_n, count_n, rate_n = sn_n[0].computePSTH(time_vect_paused, 15)
+    bins_pred_p, count_pred_p, rate_pred_p = prediction_p[0].computePSTH(
+        time_vect_paused, 15
+    )
+    bins_pred_n, count_pred_n, rate_pred_n = prediction_n[0].computePSTH(
+        time_vect_paused, 15
+    )
 
-    reference =[rate_p-rate_n, rate_pred_p - rate_pred_n]
+    reference = [rate_p - rate_n, rate_pred_p - rate_pred_n]
     time_vecs = [bins_p[:-1], bins_n[:-1]]
-    legend = ['net_sensory', 'net_prediction']
-    styles = ['g--', 'r--']
-    print('state')
+    legend = ["net_sensory", "net_prediction"]
+    styles = ["g--", "r--"]
+    print("state")
     for i in range(njt):
-            plotPopulation(time_vect_paused, stEst.pops_p[i],stEst.pops_n[i], reference, time_vecs, legend, styles,title=lgd[i],buffer_size=15)
-            plt.suptitle("State")
-            if saveFig:
-                #plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/state_"+lgd[i]+".png")
-                plt.savefig(pathFig+"state_"+lgd[i]+".png")
-    print('net')
-    bins_p,count_p,rate_p = planner.pops_p[0].computePSTH(time_vect_paused, 15)
-    bins_n,count_n,rate_n =  planner.pops_n[0].computePSTH(time_vect_paused, 15)
-    bins_stEst_p,count_stEst_p,rate_stEst_p = stEst.pops_p[0].computePSTH(time_vect_paused, 15)
-    bins_stEst_n,count_stEst_n,rate_stEst_n = stEst.pops_n[0].computePSTH(time_vect_paused, 15)
+        plotPopulation(
+            time_vect_paused,
+            stEst.pops_p[i],
+            stEst.pops_n[i],
+            reference,
+            time_vecs,
+            legend,
+            styles,
+            title=lgd[i],
+            buffer_size=15,
+        )
+        plt.suptitle("State")
+        if saveFig:
+            # plt.savefig("/home/alphabuntu/workspace/controller/complete_control/figures_thesis/cloop_nocereb/state_"+lgd[i]+".png")
+            plt.savefig(pathFig + "state_" + lgd[i] + ".png")
+    print("net")
+    bins_p, count_p, rate_p = planner.pops_p[0].computePSTH(time_vect_paused, 15)
+    bins_n, count_n, rate_n = planner.pops_n[0].computePSTH(time_vect_paused, 15)
+    bins_stEst_p, count_stEst_p, rate_stEst_p = stEst.pops_p[0].computePSTH(
+        time_vect_paused, 15
+    )
+    bins_stEst_n, count_stEst_n, rate_stEst_n = stEst.pops_n[0].computePSTH(
+        time_vect_paused, 15
+    )
 
     fig, ax = plt.subplots(2, 2)
-    ax[0,0].plot(bins_p[:-1], rate_p, label = 'planner pos' )
-    ax[0,0].plot(bins_p[:-1], rate_stEst_p, label = 'state pos' )
-    ax[0,0].set_xlabel('time')
-    ax[0,0].legend()
-    ax[1,0].plot(bins_n[:-1], rate_n, label = 'planner neg' )
-    ax[1,0].plot(bins_n[:-1], rate_stEst_n, label = 'state neg' )
-    ax[1,0].legend()
-    ax[0,1].plot(bins_p[:-1], rate_p - rate_stEst_p)
-    ax[1,1].plot(bins_n[:-1], rate_n - rate_stEst_n)
+    ax[0, 0].plot(bins_p[:-1], rate_p, label="planner pos")
+    ax[0, 0].plot(bins_p[:-1], rate_stEst_p, label="state pos")
+    ax[0, 0].set_xlabel("time")
+    ax[0, 0].legend()
+    ax[1, 0].plot(bins_n[:-1], rate_n, label="planner neg")
+    ax[1, 0].plot(bins_n[:-1], rate_stEst_n, label="state neg")
+    ax[1, 0].legend()
+    ax[0, 1].plot(bins_p[:-1], rate_p - rate_stEst_p)
+    ax[1, 1].plot(bins_n[:-1], rate_n - rate_stEst_n)
 
     plt.savefig("check_planner_state.png")
 

--- a/complete_control/neural/plot_utils.py
+++ b/complete_control/neural/plot_utils.py
@@ -459,7 +459,7 @@ def plot_overlay(
 
     fig_overl, ax = plt.subplots(1, 1, figsize=(10, 6), sharex=True)
 
-    (neural_concat, ref_mc, time_vect) = extract_neural_and_merge(metas)
+    neural_concat, ref_mc, time_vect = extract_neural_and_merge(metas)
 
     for file_prefix in populations_to_overlay:
         plot_name_t = file_prefix

--- a/complete_control/nrp_neural_engine.py
+++ b/complete_control/nrp_neural_engine.py
@@ -17,7 +17,6 @@ from nrp_core.engines.python_grpc import GrpcEngineScript
 from nrp_protobuf import nrpgenericproto_pb2, wrappers_pb2
 from utils_common.profile import Profile
 
-
 NANO_SEC = 1e-9
 
 

--- a/complete_control/nrp_status_function.py
+++ b/complete_control/nrp_status_function.py
@@ -12,5 +12,5 @@ def status_function(joint_pos_rad):
     ret = JsonRawData()
     ret.data["test_data"] = joint_pos_rad.data.value
 
-    # can be get from run_loop function: 
+    # can be get from run_loop function:
     return True, [ret]

--- a/complete_control/plant/plant_plotting.py
+++ b/complete_control/plant/plant_plotting.py
@@ -21,7 +21,7 @@ from .plant_models import JointState, JointStates, PlantPlotData
 
 plt.rcParams.update({"font.size": 15})
 
-(SHOULDER, ELBOW, HAND) = range(3)
+SHOULDER, ELBOW, HAND = range(3)
 log = structlog.get_logger(__name__)
 
 
@@ -184,7 +184,9 @@ def plot_joint_space_animated(
     ax.set_title("Joint Space Position")
     ax.set_xlim(x.min(), x.max())
     ax.set_ylim(0, np.degrees(2.8))
-    ax.secondary_yaxis("right", functions=(np.radians, np.degrees)).set_ylabel("Joint Angle (rad)")
+    ax.secondary_yaxis("right", functions=(np.radians, np.degrees)).set_ylabel(
+        "Joint Angle (rad)"
+    )
 
     legend_elements = [
         Line2D(

--- a/tests/tests_plasticity/test_Aminus_alpha.py
+++ b/tests/tests_plasticity/test_Aminus_alpha.py
@@ -1,12 +1,17 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_alpha import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times
+from validation_synapse_alpha import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+)
 import sys
 
 
 def test_Aminus_alpha():
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -17,45 +22,46 @@ def test_Aminus_alpha():
     N = 3
     M = 5
 
-
     Aminus_values = [-0.005, -0.003, -0.007]
     Aplus = 0.0
 
     weights_dict = {}
 
     for idx, value in enumerate(Aminus_values):
-        TEST_NUMBER = 7 + idx/10
+        TEST_NUMBER = 7 + idx / 10
         nest.ResetKernel()
         nest.Install("custom_stdp_module")
         nest.SetKernelStatus({"resolution": 0.1})
 
         # Create the network and tune parameters
-        IO = nest.Create("eglif_io_nestml", N) # IO
+        IO = nest.Create("eglif_io_nestml", N)  # IO
         nest.SetStatus(IO, IO_params)
-        MLI = nest.Create("eglif_mli", N) # PC
+        MLI = nest.Create("eglif_mli", N)  # PC
         nest.SetStatus(MLI, MLI_params)
-        Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-
+        Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
 
         # Connections
         nest.Connect(IO, MLI, "one_to_one", syn_spec={"receptor_type": 3})
 
-
         wr = nest.Create("weight_recorder")
-        nest.CopyModel("stdp_synapse_alpha", "my_stdp_synapse_rec", {"weight_recorder": wr, "Aplus": Aplus, "Aminus": value})
-        
-        conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-        syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
+        nest.CopyModel(
+            "stdp_synapse_alpha",
+            "my_stdp_synapse_rec",
+            {"weight_recorder": wr, "Aplus": Aplus, "Aminus": value},
+        )
 
-        nest.Connect(Gr, MLI, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+        conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+        syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+
+        nest.Connect(Gr, MLI, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
         pf_pc_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
-        IO_mli_conns = nest.GetConnections(source = IO, target = MLI)
+        IO_mli_conns = nest.GetConnections(source=IO, target=MLI)
 
-        # Devices   
+        # Devices
         cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-        MLI_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-        Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+        MLI_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+        Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
         nest.Connect(IO, cf_recorder)
         nest.Connect(MLI, MLI_recorder)
@@ -70,11 +76,33 @@ def test_Aminus_alpha():
         weight_matrix = reformat_weights(weights)
 
         weights_dict[idx] = weight_matrix
-        corrected_cf_tms, cf_evs, corrected_MLI_tms, MLI_evs, MLI_complex_tms, MLI_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
-        
+        (
+            corrected_cf_tms,
+            cf_evs,
+            corrected_MLI_tms,
+            MLI_evs,
+            MLI_complex_tms,
+            MLI_complex_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+        ) = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
+
         data = nest.GetStatus(wr)[0]
 
-        plot_synaptic_weight(pf_pc_conns, data, IO, MLI, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, TEST_NUMBER) 
+        plot_synaptic_weight(
+            pf_pc_conns,
+            data,
+            IO,
+            MLI,
+            Gr,
+            corrected_cf_tms,
+            cf_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+            corrected_MLI_tms,
+            MLI_evs,
+            TEST_NUMBER,
+        )
 
     # Check across the trials if, when LTD happens, the ratio of weights is the same of Aminus
 
@@ -97,35 +125,35 @@ def test_Aminus_alpha():
         diff_wgh_2 = np.diff(wgh_2)
         diff_wgh_3 = np.diff(wgh_3)
 
-        LTD_index_1 = np.where(diff_wgh_1 < 0) # Non sto considerando la situazione dove il peso è già 0 e rimane 0
+        LTD_index_1 = np.where(
+            diff_wgh_1 < 0
+        )  # Non sto considerando la situazione dove il peso è già 0 e rimane 0
         LTD_index_2 = np.where(diff_wgh_2 < 0)
-        LTD_index_3 = np.where(diff_wgh_3 <  0)
-
+        LTD_index_3 = np.where(diff_wgh_3 < 0)
 
         # First assert LTD happens at the same times
-        assert(np.array_equal(LTD_index_1, LTD_index_2))
-        assert(np.array_equal(LTD_index_2, LTD_index_3))
-        
+        assert np.array_equal(LTD_index_1, LTD_index_2)
+        assert np.array_equal(LTD_index_2, LTD_index_3)
+
         LTD_amounts_1 = diff_wgh_1[LTD_index_1]
         LTD_amounts_2 = diff_wgh_2[LTD_index_2]
         LTD_amounts_3 = diff_wgh_3[LTD_index_3]
 
         # Check that the ratio corresponds to the ratio between the Aminus values
         ratio1 = np.round(np.average(LTD_amounts_2) / np.average(LTD_amounts_1), 1)
-        ratio2 = np.round(np.average(LTD_amounts_3 )/ np.average(LTD_amounts_1), 1)
-        ratio3 = np.round(np.average(LTD_amounts_3)/np.average(LTD_amounts_2), 1)
+        ratio2 = np.round(np.average(LTD_amounts_3) / np.average(LTD_amounts_1), 1)
+        ratio3 = np.round(np.average(LTD_amounts_3) / np.average(LTD_amounts_2), 1)
 
         target_value = round(Aminus_values[1] / Aminus_values[0], 1)
-        #print(ratio1)
-        #print(target_value)
-        assert np.allclose(ratio1, target_value, atol=0.1)   
+        # print(ratio1)
+        # print(target_value)
+        assert np.allclose(ratio1, target_value, atol=0.1)
         target_value = round(Aminus_values[2] / Aminus_values[0], 1)
-        #print(ratio2)
-        #print(target_value)
+        # print(ratio2)
+        # print(target_value)
         assert np.allclose(ratio2, target_value, atol=0.1)
-    
-        target_value = round(Aminus_values[2] / Aminus_values[1], 1)
-        #print(ratio3)
-        #print(target_value)
-        assert np.allclose(ratio3, target_value, atol=0.1)
 
+        target_value = round(Aminus_values[2] / Aminus_values[1], 1)
+        # print(ratio3)
+        # print(target_value)
+        assert np.allclose(ratio3, target_value, atol=0.1)

--- a/tests/tests_plasticity/test_Aminus_sinexp.py
+++ b/tests/tests_plasticity/test_Aminus_sinexp.py
@@ -1,12 +1,17 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_sinexp import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times
+from validation_synapse_sinexp import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+)
 import sys
 
 
 def test_Aminus_sinexp():
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -26,38 +31,41 @@ def test_Aminus_sinexp():
     weights_dict = {}
 
     for idx, value in enumerate(Aminus_values):
-        TEST_NUMBER = 7 + idx/10
+        TEST_NUMBER = 7 + idx / 10
         nest.ResetKernel()
         nest.Install("custom_stdp_module")
         nest.SetKernelStatus({"resolution": 0.1})
 
         # Create the network and tune parameters
-        IO = nest.Create("eglif_io_nestml", N) # IO
+        IO = nest.Create("eglif_io_nestml", N)  # IO
         nest.SetStatus(IO, IO_params)
-        PC = nest.Create("eglif_pc_nestml", N) # PC
+        PC = nest.Create("eglif_pc_nestml", N)  # PC
         nest.SetStatus(PC, PC_params)
-        Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-        #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+        Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+        # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
         # Connections
         nest.Connect(IO, PC, "one_to_one", syn_spec={"receptor_type": 5})
-    
 
         wr = nest.Create("weight_recorder")
-        nest.CopyModel("stdp_synapse_sinexp", "my_stdp_synapse_rec", {"weight_recorder": wr, "Aplus": Aplus,  "Aminus": value})
-        
-        conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-        syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
+        nest.CopyModel(
+            "stdp_synapse_sinexp",
+            "my_stdp_synapse_rec",
+            {"weight_recorder": wr, "Aplus": Aplus, "Aminus": value},
+        )
 
-        nest.Connect(Gr, PC, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+        conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+        syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+
+        nest.Connect(Gr, PC, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
         pf_pc_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
-        IO_pc_conns = nest.GetConnections(source = IO, target = PC)
+        IO_pc_conns = nest.GetConnections(source=IO, target=PC)
 
-        # Devices   
+        # Devices
         cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-        PC_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-        Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+        PC_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+        Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
         nest.Connect(IO, cf_recorder)
         nest.Connect(PC, PC_recorder)
@@ -72,11 +80,33 @@ def test_Aminus_sinexp():
         weight_matrix = reformat_weights(weights)
 
         weights_dict[idx] = weight_matrix
-        corrected_cf_tms, cf_evs, corrected_PC_tms, PC_evs, PC_complex_tms, PC_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
-        
+        (
+            corrected_cf_tms,
+            cf_evs,
+            corrected_PC_tms,
+            PC_evs,
+            PC_complex_tms,
+            PC_complex_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+        ) = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
+
         data = nest.GetStatus(wr)[0]
 
-        plot_synaptic_weight(pf_pc_conns, data, IO, PC, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, TEST_NUMBER) 
+        plot_synaptic_weight(
+            pf_pc_conns,
+            data,
+            IO,
+            PC,
+            Gr,
+            corrected_cf_tms,
+            cf_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+            corrected_PC_tms,
+            PC_evs,
+            TEST_NUMBER,
+        )
 
     # Check across the trials if, when LTD happens, the ratio of weights is the same of Aminus
 
@@ -99,36 +129,35 @@ def test_Aminus_sinexp():
         diff_wgh_2 = np.diff(wgh_2)
         diff_wgh_3 = np.diff(wgh_3)
 
-        LTD_index_1 = np.where(diff_wgh_1 < 0) # Non sto considerando la situazione dove il peso è già 0 e rimane 0
+        LTD_index_1 = np.where(
+            diff_wgh_1 < 0
+        )  # Non sto considerando la situazione dove il peso è già 0 e rimane 0
         LTD_index_2 = np.where(diff_wgh_2 < 0)
-        LTD_index_3 = np.where(diff_wgh_3 <  0)
-
+        LTD_index_3 = np.where(diff_wgh_3 < 0)
 
         # First assert LTD happens at the same times
-        assert(np.array_equal(LTD_index_1, LTD_index_2))
-        assert(np.array_equal(LTD_index_2, LTD_index_3))
-        
+        assert np.array_equal(LTD_index_1, LTD_index_2)
+        assert np.array_equal(LTD_index_2, LTD_index_3)
+
         LTD_amounts_1 = diff_wgh_1[LTD_index_1]
         LTD_amounts_2 = diff_wgh_2[LTD_index_2]
         LTD_amounts_3 = diff_wgh_3[LTD_index_3]
 
         # Check that the ratio corresponds to the ratio between the Aminus values
         ratio1 = np.round(np.average(LTD_amounts_2) / np.average(LTD_amounts_1), 1)
-        ratio2 = np.round(np.average(LTD_amounts_3 )/ np.average(LTD_amounts_1), 1)
-        ratio3 = np.round(np.average(LTD_amounts_3)/np.average(LTD_amounts_2), 1)
-    
+        ratio2 = np.round(np.average(LTD_amounts_3) / np.average(LTD_amounts_1), 1)
+        ratio3 = np.round(np.average(LTD_amounts_3) / np.average(LTD_amounts_2), 1)
 
         target_value = round(Aminus_values[1] / Aminus_values[0], 1)
-        #print(ratio1)
-        #print(target_value)
-        assert np.allclose(ratio1, target_value,atol= 0.1)   
+        # print(ratio1)
+        # print(target_value)
+        assert np.allclose(ratio1, target_value, atol=0.1)
         target_value = round(Aminus_values[2] / Aminus_values[0], 1)
-        #print(ratio2)
-        #print(target_value)
-        assert np.allclose(ratio2, target_value, atol= 0.1)
-    
-        target_value = round(Aminus_values[2] / Aminus_values[1], 1)
-        #print(ratio3)
-        #print(target_value)
-        assert np.allclose(ratio3, target_value, atol= 0.1)
+        # print(ratio2)
+        # print(target_value)
+        assert np.allclose(ratio2, target_value, atol=0.1)
 
+        target_value = round(Aminus_values[2] / Aminus_values[1], 1)
+        # print(ratio3)
+        # print(target_value)
+        assert np.allclose(ratio3, target_value, atol=0.1)

--- a/tests/tests_plasticity/test_Aplus_alpha.py
+++ b/tests/tests_plasticity/test_Aplus_alpha.py
@@ -1,12 +1,18 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_alpha import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times, plot_LTP
+from validation_synapse_alpha import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+    plot_LTP,
+)
 import sys
 
 
 def test_Aplus_alpha():
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -18,40 +24,43 @@ def test_Aplus_alpha():
     M = 5
 
     Aminus_value = 0.0
-    Aplus_values = [ 0.0001 ,  0.0005,  0.0006 ]
+    Aplus_values = [0.0001, 0.0005, 0.0006]
 
     for trial in range(N):
-        TEST_NUMBER = 6 + trial/10
+        TEST_NUMBER = 6 + trial / 10
         nest.ResetKernel()
         nest.Install("custom_stdp_module")
         nest.SetKernelStatus({"resolution": 0.1})
 
         # Create the network and tune parameters
-        IO = nest.Create("eglif_io_nestml", N) # IO
+        IO = nest.Create("eglif_io_nestml", N)  # IO
         nest.SetStatus(IO, IO_params)
-        MLI = nest.Create("eglif_mli", N) # PC
+        MLI = nest.Create("eglif_mli", N)  # PC
         nest.SetStatus(MLI, MLI_params)
-        Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-        #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+        Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+        # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
         # Connections
         nest.Connect(IO, MLI, "one_to_one", syn_spec={"receptor_type": 3})
 
-        
         wr = nest.Create("weight_recorder")
-        nest.CopyModel("stdp_synapse_alpha", "my_stdp_synapse_rec", {"weight_recorder": wr,  "Aplus": Aplus_values[trial], "Aminus": -0.000})
-        
-        conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-        syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-        nest.Connect(Gr, MLI, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+        nest.CopyModel(
+            "stdp_synapse_alpha",
+            "my_stdp_synapse_rec",
+            {"weight_recorder": wr, "Aplus": Aplus_values[trial], "Aminus": -0.000},
+        )
 
-        pf_pc_conns = nest.GetConnections( synapse_model="my_stdp_synapse_rec")
-        IO_pc_conns = nest.GetConnections(source = IO, target = MLI)
-        
-        # Devices   
+        conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+        syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+        nest.Connect(Gr, MLI, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
+
+        pf_pc_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
+        IO_pc_conns = nest.GetConnections(source=IO, target=MLI)
+
+        # Devices
         cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-        MLI_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-        Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+        MLI_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+        Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
         nest.Connect(IO, cf_recorder)
         nest.Connect(MLI, MLI_recorder)
@@ -65,22 +74,42 @@ def test_Aplus_alpha():
 
         weight_matrix = reformat_weights(weights)
         print(weight_matrix)
-        corrected_cf_tms, cf_evs, corrected_MLI_tms, MLI_evs, MLI_complex_tms, MLI_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
+        (
+            corrected_cf_tms,
+            cf_evs,
+            corrected_MLI_tms,
+            MLI_evs,
+            MLI_complex_tms,
+            MLI_complex_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+        ) = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
         data = nest.GetStatus(wr)[0]
-        
-        
-        plot_synaptic_weight(pf_pc_conns, data, IO, MLI, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, TEST_NUMBER) 
-        
+
+        plot_synaptic_weight(
+            pf_pc_conns,
+            data,
+            IO,
+            MLI,
+            Gr,
+            corrected_cf_tms,
+            cf_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+            corrected_MLI_tms,
+            MLI_evs,
+            TEST_NUMBER,
+        )
+
         count_errors = []
-        
+
         # Assert that if there is LTP, it is of Aplus
         for n, conn in enumerate(pf_pc_conns):
-            
+
             diff_weights = np.round(np.diff(weight_matrix[n, :]), 3)
 
             assert np.all(diff_weights >= 0)
             for timestep, diff in enumerate(diff_weights):
                 if diff > 0 and diff != Aplus_values[trial]:
                     count_errors.append(diff)
-                    #print(count_errors)
-                    
+                    # print(count_errors)

--- a/tests/tests_plasticity/test_Aplus_sinexp.py
+++ b/tests/tests_plasticity/test_Aplus_sinexp.py
@@ -1,12 +1,18 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_sinexp import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times, plot_LTP
+from validation_synapse_sinexp import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+    plot_LTP,
+)
 import sys
 
 
 def test_Aplus_sinexp():
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -18,41 +24,49 @@ def test_Aplus_sinexp():
     M = 5
 
     Aminus_value = 0.0
-    Aplus_values = [ 0.0001 ,  0.0005,  0.0006 ]
+    Aplus_values = [0.0001, 0.0005, 0.0006]
 
     for trial in range(N):
-        TEST_NUMBER = 6 + trial/10
+        TEST_NUMBER = 6 + trial / 10
         nest.ResetKernel()
         nest.Install("custom_stdp_module")
         nest.SetKernelStatus({"resolution": 0.1})
 
         # Create the network and tune parameters
-        IO = nest.Create("eglif_io_nestml", N) # IO
+        IO = nest.Create("eglif_io_nestml", N)  # IO
         nest.SetStatus(IO, IO_params)
-        PC = nest.Create("eglif_pc_nestml", N) # PC
+        PC = nest.Create("eglif_pc_nestml", N)  # PC
         nest.SetStatus(PC, PC_params)
-        Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-        #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+        Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+        # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
         # Connections
-    
+
         nest.Connect(IO, PC, "one_to_one", syn_spec={"receptor_type": 5})
 
-        
         wr = nest.Create("weight_recorder")
-        nest.CopyModel("stdp_synapse_sinexp", "my_stdp_synapse_rec", {"weight_recorder": wr,  "Aplus": Aplus_values[trial],"t_0":150,  "Aminus": -0.000})
-        
-        conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-        syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-        nest.Connect(Gr, PC, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+        nest.CopyModel(
+            "stdp_synapse_sinexp",
+            "my_stdp_synapse_rec",
+            {
+                "weight_recorder": wr,
+                "Aplus": Aplus_values[trial],
+                "t_0": 150,
+                "Aminus": -0.000,
+            },
+        )
 
-        pf_pc_conns = nest.GetConnections( synapse_model="my_stdp_synapse_rec")
-        IO_pc_conns = nest.GetConnections(source = IO, target = PC)
-        
-        # Devices   
+        conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+        syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+        nest.Connect(Gr, PC, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
+
+        pf_pc_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
+        IO_pc_conns = nest.GetConnections(source=IO, target=PC)
+
+        # Devices
         cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-        PC_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-        Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+        PC_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+        Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
         nest.Connect(IO, cf_recorder)
         nest.Connect(PC, PC_recorder)
@@ -66,22 +80,42 @@ def test_Aplus_sinexp():
 
         weight_matrix = reformat_weights(weights)
         print(weight_matrix)
-        corrected_cf_tms, cf_evs, corrected_PC_tms, PC_evs, PC_complex_tms, PC_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
+        (
+            corrected_cf_tms,
+            cf_evs,
+            corrected_PC_tms,
+            PC_evs,
+            PC_complex_tms,
+            PC_complex_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+        ) = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
         data = nest.GetStatus(wr)[0]
-        
-        
-        plot_synaptic_weight(pf_pc_conns, data, IO, PC, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, TEST_NUMBER) 
-    
+
+        plot_synaptic_weight(
+            pf_pc_conns,
+            data,
+            IO,
+            PC,
+            Gr,
+            corrected_cf_tms,
+            cf_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+            corrected_PC_tms,
+            PC_evs,
+            TEST_NUMBER,
+        )
+
         count_errors = []
-        
+
         # Assert that if there is LTP, it is of Aplus
         for n, conn in enumerate(pf_pc_conns):
-            
+
             diff_weights = np.round(np.diff(weight_matrix[n, :]), 3)
 
             assert np.all(diff_weights >= 0)
             for timestep, diff in enumerate(diff_weights):
                 if diff > 0 and diff != Aplus_values[trial]:
                     count_errors.append(diff)
-                    #print(count_errors)
-                    
+                    # print(count_errors)

--- a/tests/tests_plasticity/test_complex_Gr_spike_alpha.py
+++ b/tests/tests_plasticity/test_complex_Gr_spike_alpha.py
@@ -1,12 +1,19 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_alpha import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times, plot_complex_spike
+from validation_synapse_alpha import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+    plot_complex_spike,
+)
 import sys
+
 
 def test_complex_Gr_spike_alpha():
     TEST_NUMBER = 4
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -20,16 +27,20 @@ def test_complex_Gr_spike_alpha():
 
     N = 3
     M = 5
-    IO = nest.Create("eglif_io_nestml", N) # IO
-    #nest.SetStatus(IO, IO_params)
-    MLI = nest.Create("eglif_mli", N) # MLI
+    IO = nest.Create("eglif_io_nestml", N)  # IO
+    # nest.SetStatus(IO, IO_params)
+    MLI = nest.Create("eglif_mli", N)  # MLI
     nest.SetStatus(MLI, MLI_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
-    complex_spike_time= [997]
-    complex_spike_gen = nest.Create("spike_generator", {"spike_times": complex_spike_time})
-    nest.Connect(complex_spike_gen, IO, "all_to_all", {"weight": 1000, "receptor_type": 1})
+    complex_spike_time = [997]
+    complex_spike_gen = nest.Create(
+        "spike_generator", {"spike_times": complex_spike_time}
+    )
+    nest.Connect(
+        complex_spike_gen, IO, "all_to_all", {"weight": 1000, "receptor_type": 1}
+    )
 
     # Set threshold of IOs and GrCs to 0.0 mV to avoid autonomous firing
     nest.SetStatus(IO, {"V_th": 0.0})
@@ -38,25 +49,21 @@ def test_complex_Gr_spike_alpha():
     # Connections
     nest.Connect(IO, MLI, "one_to_one", syn_spec={"receptor_type": 3})
 
-
     wr = nest.Create("weight_recorder")
     nest.CopyModel("stdp_synapse_alpha", "my_stdp_synapse_rec", {"weight_recorder": wr})
-    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-    nest.Connect(Gr, MLI, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+    conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+    nest.Connect(Gr, MLI, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    MLI_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+    MLI_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(MLI, MLI_recorder)
     nest.Connect(Gr, Gr_recorder)
 
-
-
     pf_mli_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
-
 
     weights = []
     for i in range(1000):
@@ -65,9 +72,32 @@ def test_complex_Gr_spike_alpha():
 
     weight_matrix = reformat_weights(weights)
 
-    corrected_cf_tms, cf_evs, corrected_MLI_tms, MLI_evs, MLI_complex_tms, MLI_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_MLI_tms,
+        MLI_evs,
+        MLI_complex_tms,
+        MLI_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
-    plot_complex_spike(pf_mli_conns, data, weight_matrix, IO, MLI, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, TEST_NUMBER)
+    plot_complex_spike(
+        pf_mli_conns,
+        data,
+        weight_matrix,
+        IO,
+        MLI,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_MLI_tms,
+        MLI_evs,
+        TEST_NUMBER,
+    )
 
-    assert (np.all(weight_matrix == 5 ))
+    assert np.all(weight_matrix == 5)

--- a/tests/tests_plasticity/test_complex_Gr_spike_sinexp.py
+++ b/tests/tests_plasticity/test_complex_Gr_spike_sinexp.py
@@ -1,12 +1,19 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_sinexp import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times, plot_complex_spike
+from validation_synapse_sinexp import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+    plot_complex_spike,
+)
 import sys
+
 
 def test_complex_Gr_spike_sinexp():
     TEST_NUMBER = 4
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -20,16 +27,20 @@ def test_complex_Gr_spike_sinexp():
 
     N = 3
     M = 5
-    IO = nest.Create("eglif_io_nestml", N) # IO
-    #nest.SetStatus(IO, IO_params)
-    PC = nest.Create("eglif_pc_nestml", N) # PC
+    IO = nest.Create("eglif_io_nestml", N)  # IO
+    # nest.SetStatus(IO, IO_params)
+    PC = nest.Create("eglif_pc_nestml", N)  # PC
     nest.SetStatus(PC, PC_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
-    complex_spike_time= [997]
-    complex_spike_gen = nest.Create("spike_generator", {"spike_times": complex_spike_time})
-    nest.Connect(complex_spike_gen, IO, "all_to_all", {"weight": 1000, "receptor_type": 1})
+    complex_spike_time = [997]
+    complex_spike_gen = nest.Create(
+        "spike_generator", {"spike_times": complex_spike_time}
+    )
+    nest.Connect(
+        complex_spike_gen, IO, "all_to_all", {"weight": 1000, "receptor_type": 1}
+    )
 
     # Set threshold of IOs and GrCs to 0.0 mV to avoid autonomous firing
     nest.SetStatus(IO, {"V_th": 0.0})
@@ -38,25 +49,25 @@ def test_complex_Gr_spike_sinexp():
     # Connections
     nest.Connect(IO, PC, "one_to_one", syn_spec={"receptor_type": 5})
 
-
     wr = nest.Create("weight_recorder")
-    nest.CopyModel("stdp_synapse_sinexp", "my_stdp_synapse_rec", {"weight_recorder": wr,"t_0":150})
-    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-    nest.Connect(Gr, PC, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+    nest.CopyModel(
+        "stdp_synapse_sinexp",
+        "my_stdp_synapse_rec",
+        {"weight_recorder": wr, "t_0": 150},
+    )
+    conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+    nest.Connect(Gr, PC, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    PC_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+    PC_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(PC, PC_recorder)
     nest.Connect(Gr, Gr_recorder)
 
-
-
     pf_pc_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
-
 
     weights = []
     for i in range(1000):
@@ -65,9 +76,32 @@ def test_complex_Gr_spike_sinexp():
 
     weight_matrix = reformat_weights(weights)
 
-    corrected_cf_tms, cf_evs, corrected_PC_tms, PC_evs, PC_complex_tms, PC_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_PC_tms,
+        PC_evs,
+        PC_complex_tms,
+        PC_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
-    plot_complex_spike(pf_pc_conns, data, weight_matrix, IO, PC, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, TEST_NUMBER)
+    plot_complex_spike(
+        pf_pc_conns,
+        data,
+        weight_matrix,
+        IO,
+        PC,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_PC_tms,
+        PC_evs,
+        TEST_NUMBER,
+    )
 
-    assert (np.all(weight_matrix == 0.14 ))
+    assert np.all(weight_matrix == 0.14)

--- a/tests/tests_plasticity/test_general_alpha.py
+++ b/tests/tests_plasticity/test_general_alpha.py
@@ -1,11 +1,18 @@
 import nest
 import json
-from validation_synapse_alpha import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times, plot_LTP
+from validation_synapse_alpha import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+    plot_LTP,
+)
 import sys
+
 
 def test_general_alpha():
     TEST_NUMBER = 1
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -19,33 +26,34 @@ def test_general_alpha():
 
     N = 3
     M = 5
-    IO = nest.Create("eglif_io_nestml", N) # IO
+    IO = nest.Create("eglif_io_nestml", N)  # IO
     nest.SetStatus(IO, IO_params)
-    MLI = nest.Create("eglif_mli", N) # PC
+    MLI = nest.Create("eglif_mli", N)  # PC
     nest.SetStatus(MLI, MLI_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
-
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
     # Lower threshold of GrCs to increase their firing rate
 
     nest.SetStatus(Gr, {"V_th": -71.0})
 
-
     # Connections
     nest.Connect(IO, MLI, "one_to_one", syn_spec={"receptor_type": 3})
 
-
     wr = nest.Create("weight_recorder")
-    nest.CopyModel("stdp_synapse_alpha", "my_stdp_synapse_rec", {"weight_recorder": wr,"weight":1, "Aplus" : 0.05,"Aminus": -0.1})
-    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-    nest.Connect(Gr, MLI, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+    nest.CopyModel(
+        "stdp_synapse_alpha",
+        "my_stdp_synapse_rec",
+        {"weight_recorder": wr, "weight": 1, "Aplus": 0.05, "Aminus": -0.1},
+    )
+    conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+    nest.Connect(Gr, MLI, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
     # Devices
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    MLI_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+    MLI_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(MLI, MLI_recorder)
@@ -53,16 +61,37 @@ def test_general_alpha():
 
     pf_mli_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
 
-
     weights = []
     for i in range(1000):
         nest.Simulate(1.0)
         weights.append(nest.GetStatus(pf_mli_conns, "weight"))
-        #print(nest.GetStatus(pf_pc_conns, "weight"))
+        # print(nest.GetStatus(pf_pc_conns, "weight"))
     weight_matrix = reformat_weights(weights)
-    #print(pf_pc_conns)
-    corrected_cf_tms, cf_evs, corrected_MLI_tms, MLI_evs, MLI_complex_tms, MLI_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
+    # print(pf_pc_conns)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_MLI_tms,
+        MLI_evs,
+        MLI_complex_tms,
+        MLI_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
 
-    plot_synaptic_weight(pf_mli_conns, data, IO, MLI, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, TEST_NUMBER)
+    plot_synaptic_weight(
+        pf_mli_conns,
+        data,
+        IO,
+        MLI,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_MLI_tms,
+        MLI_evs,
+        TEST_NUMBER,
+    )

--- a/tests/tests_plasticity/test_general_sinexp.py
+++ b/tests/tests_plasticity/test_general_sinexp.py
@@ -1,12 +1,18 @@
 import nest
 import json
-from validation_synapse_sinexp import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times, plot_LTP
+from validation_synapse_sinexp import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+    plot_LTP,
+)
 import sys
 
 
 def test_general_sinexp():
     TEST_NUMBER = 1
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -20,13 +26,12 @@ def test_general_sinexp():
 
     N = 3
     M = 5
-    IO = nest.Create("eglif_io_nestml", N) # IO
+    IO = nest.Create("eglif_io_nestml", N)  # IO
     nest.SetStatus(IO, IO_params)
-    PC = nest.Create("eglif_pc_nestml", N) # PC
+    PC = nest.Create("eglif_pc_nestml", N)  # PC
     nest.SetStatus(PC, PC_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
-
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
     # Lower threshold of GrCs to increase their firing rate
     nest.SetStatus(Gr, {"V_th": -70.0})
@@ -34,17 +39,20 @@ def test_general_sinexp():
     # Connections
     nest.Connect(IO, PC, "one_to_one", syn_spec={"receptor_type": 5})
 
-
     wr = nest.Create("weight_recorder")
-    nest.CopyModel("stdp_synapse_sinexp", "my_stdp_synapse_rec", {"weight_recorder": wr, "t_0":150, "Aplus": 0.002})
-    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-    nest.Connect(Gr, PC, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+    nest.CopyModel(
+        "stdp_synapse_sinexp",
+        "my_stdp_synapse_rec",
+        {"weight_recorder": wr, "t_0": 150, "Aplus": 0.002},
+    )
+    conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+    nest.Connect(Gr, PC, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
     # Devices
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    PC_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+    PC_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(PC, PC_recorder)
@@ -52,16 +60,37 @@ def test_general_sinexp():
 
     pf_pc_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
 
-
     weights = []
     for i in range(1000):
         nest.Simulate(1.0)
         weights.append(nest.GetStatus(pf_pc_conns, "weight"))
-        #print(nest.GetStatus(pf_pc_conns, "weight"))
+        # print(nest.GetStatus(pf_pc_conns, "weight"))
     weight_matrix = reformat_weights(weights)
-    #print(pf_pc_conns)
-    corrected_cf_tms, cf_evs, corrected_PC_tms, PC_evs, PC_complex_tms, PC_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
+    # print(pf_pc_conns)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_PC_tms,
+        PC_evs,
+        PC_complex_tms,
+        PC_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
 
-    plot_synaptic_weight(pf_pc_conns, data, IO, PC, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, TEST_NUMBER)
+    plot_synaptic_weight(
+        pf_pc_conns,
+        data,
+        IO,
+        PC,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_PC_tms,
+        PC_evs,
+        TEST_NUMBER,
+    )

--- a/tests/tests_plasticity/test_kernel_alpha.py
+++ b/tests/tests_plasticity/test_kernel_alpha.py
@@ -1,11 +1,18 @@
 import nest
 import json
-from validation_synapse_alpha import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times, plot_LTD
+from validation_synapse_alpha import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+    plot_LTD,
+)
 import sys
+
 
 def test_alpha_kernel():
     TEST_NUMBER = 9
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -19,57 +26,107 @@ def test_alpha_kernel():
 
     N = 1
     M = 1
-    IO = nest.Create("eglif_io_nestml", N) # IO
-    #nest.SetStatus(IO, IO_params)
-    MLI = nest.Create("eglif_mli", N) # MLI
+    IO = nest.Create("eglif_io_nestml", N)  # IO
+    # nest.SetStatus(IO, IO_params)
+    MLI = nest.Create("eglif_mli", N)  # MLI
     nest.SetStatus(MLI, MLI_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
     simple_spike_times = [
-        1.0, 210.0, 420.0, 630.0, 840.0, 1050.0, 1260.0, 1470.0, 1680.0, 1890.0,
-        2100.0, 2310.0, 2520.0, 2730.0, 2940.0, 3150.0, 3360.0, 3570.0, 3780.0, 3990.0, 4200.0
+        1.0,
+        210.0,
+        420.0,
+        630.0,
+        840.0,
+        1050.0,
+        1260.0,
+        1470.0,
+        1680.0,
+        1890.0,
+        2100.0,
+        2310.0,
+        2520.0,
+        2730.0,
+        2940.0,
+        3150.0,
+        3360.0,
+        3570.0,
+        3780.0,
+        3990.0,
+        4200.0,
     ]
 
     complex_spike_times = [
-        201.0, 400.0, 600.0, 800.0, 1000.0, 1200.0, 1400.0, 1600.0, 1800.0, 2000.0,
-        2200.0, 2400.0, 2600.0, 2800.0, 3000.0, 3200.0, 3400.0, 3600.0, 3800.0, 4000.0, 4200.0
+        201.0,
+        400.0,
+        600.0,
+        800.0,
+        1000.0,
+        1200.0,
+        1400.0,
+        1600.0,
+        1800.0,
+        2000.0,
+        2200.0,
+        2400.0,
+        2600.0,
+        2800.0,
+        3000.0,
+        3200.0,
+        3400.0,
+        3600.0,
+        3800.0,
+        4000.0,
+        4200.0,
     ]
 
-    simple_spike_gen = nest.Create("spike_generator", {"spike_times": simple_spike_times})
-    complex_spike_gen = nest.Create("spike_generator", {"spike_times": complex_spike_times})
+    simple_spike_gen = nest.Create(
+        "spike_generator", {"spike_times": simple_spike_times}
+    )
+    complex_spike_gen = nest.Create(
+        "spike_generator", {"spike_times": complex_spike_times}
+    )
 
-    nest.Connect(simple_spike_gen, Gr, "all_to_all", {"weight": 100, "receptor_type": 1})
-    nest.Connect(complex_spike_gen, IO, "all_to_all", {"weight": 100, "receptor_type": 1})
+    nest.Connect(
+        simple_spike_gen, Gr, "all_to_all", {"weight": 100, "receptor_type": 1}
+    )
+    nest.Connect(
+        complex_spike_gen, IO, "all_to_all", {"weight": 100, "receptor_type": 1}
+    )
 
     # Set thresholds of IOs and GrCs to 0.0 to avoid autonomous firing
 
     nest.SetStatus(Gr, {"V_th": 0.0})
     nest.SetStatus(IO, {"V_th": 0.0})
 
-
-
     # Connections
     nest.Connect(IO, MLI, "one_to_one", syn_spec={"receptor_type": 3})
 
-
     wr = nest.Create("weight_recorder")
-    nest.CopyModel("stdp_synapse_alpha", "my_stdp_synapse_rec", {"weight_recorder": wr ,"receptor_type": 1,"Aminus":0.0,"weight":50,"tau":50.0, "Aplus":0.5})
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec"}
-    nest.Connect(Gr, MLI, syn_spec = syn_spec_dict)
+    nest.CopyModel(
+        "stdp_synapse_alpha",
+        "my_stdp_synapse_rec",
+        {
+            "weight_recorder": wr,
+            "receptor_type": 1,
+            "Aminus": 0.0,
+            "weight": 50,
+            "tau": 50.0,
+            "Aplus": 0.5,
+        },
+    )
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec"}
+    nest.Connect(Gr, MLI, syn_spec=syn_spec_dict)
 
     # Devices
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    MLI_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-
+    MLI_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(MLI, MLI_recorder)
     nest.Connect(Gr, Gr_recorder)
-
-
-
 
     pf_mli_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
 
@@ -77,14 +134,34 @@ def test_alpha_kernel():
     for i in range(4300):
         nest.Simulate(1.0)
         weights.append(nest.GetStatus(pf_mli_conns, "weight"))
-        
 
     weight_matrix = reformat_weights(weights)
     print(weight_matrix)
 
-
-    corrected_cf_tms, cf_evs, corrected_PC_tms, MLI_evs, MLI_complex_tms, MLI_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_PC_tms,
+        MLI_evs,
+        MLI_complex_tms,
+        MLI_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
 
-    plot_synaptic_weight(pf_mli_conns, data, IO, MLI, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, MLI_evs, TEST_NUMBER)
+    plot_synaptic_weight(
+        pf_mli_conns,
+        data,
+        IO,
+        MLI,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_PC_tms,
+        MLI_evs,
+        TEST_NUMBER,
+    )

--- a/tests/tests_plasticity/test_kernel_sinexp.py
+++ b/tests/tests_plasticity/test_kernel_sinexp.py
@@ -1,12 +1,17 @@
 import nest
 import json
-from validation_synapse_sinexp import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times, plot_LTD
-
+from validation_synapse_sinexp import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+    plot_LTD,
+)
 
 
 def test_sinexp_kernel():
     TEST_NUMBER = 9
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -20,55 +25,107 @@ def test_sinexp_kernel():
 
     N = 1
     M = 1
-    IO = nest.Create("eglif_io_nestml", N) # IO
-    #nest.SetStatus(IO, IO_params)
-    PC = nest.Create("eglif_pc_nestml", N) # PC
+    IO = nest.Create("eglif_io_nestml", N)  # IO
+    # nest.SetStatus(IO, IO_params)
+    PC = nest.Create("eglif_pc_nestml", N)  # PC
     nest.SetStatus(PC, PC_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
     simple_spike_times = [
-        1.0, 210.0, 420.0, 630.0, 840.0, 1050.0, 1260.0, 1470.0, 1680.0, 1890.0,
-        2100.0, 2310.0, 2520.0, 2730.0, 2940.0, 3150.0, 3360.0, 3570.0, 3780.0, 3990.0, 4200.0
+        1.0,
+        210.0,
+        420.0,
+        630.0,
+        840.0,
+        1050.0,
+        1260.0,
+        1470.0,
+        1680.0,
+        1890.0,
+        2100.0,
+        2310.0,
+        2520.0,
+        2730.0,
+        2940.0,
+        3150.0,
+        3360.0,
+        3570.0,
+        3780.0,
+        3990.0,
+        4200.0,
     ]
 
     complex_spike_times = [
-        201.0, 400.0, 600.0, 800.0, 1000.0, 1200.0, 1400.0, 1600.0, 1800.0, 2000.0,
-        2200.0, 2400.0, 2600.0, 2800.0, 3000.0, 3200.0, 3400.0, 3600.0, 3800.0, 4000.0, 4200.0
+        201.0,
+        400.0,
+        600.0,
+        800.0,
+        1000.0,
+        1200.0,
+        1400.0,
+        1600.0,
+        1800.0,
+        2000.0,
+        2200.0,
+        2400.0,
+        2600.0,
+        2800.0,
+        3000.0,
+        3200.0,
+        3400.0,
+        3600.0,
+        3800.0,
+        4000.0,
+        4200.0,
     ]
 
-    simple_spike_gen = nest.Create("spike_generator", {"spike_times": simple_spike_times})
-    complex_spike_gen = nest.Create("spike_generator", {"spike_times": complex_spike_times})
+    simple_spike_gen = nest.Create(
+        "spike_generator", {"spike_times": simple_spike_times}
+    )
+    complex_spike_gen = nest.Create(
+        "spike_generator", {"spike_times": complex_spike_times}
+    )
 
-    nest.Connect(simple_spike_gen, Gr, "all_to_all", {"weight": 1000, "receptor_type": 1})
-    nest.Connect(complex_spike_gen, IO, "all_to_all", {"weight": 1000, "receptor_type": 1})
+    nest.Connect(
+        simple_spike_gen, Gr, "all_to_all", {"weight": 1000, "receptor_type": 1}
+    )
+    nest.Connect(
+        complex_spike_gen, IO, "all_to_all", {"weight": 1000, "receptor_type": 1}
+    )
 
     # Set thresholds of IOs and GrCs to 0.0 to avoid autonomous firing
 
     nest.SetStatus(Gr, {"V_th": 0.0})
     nest.SetStatus(IO, {"V_th": 0.0})
 
-
     # Connections
     nest.Connect(IO, PC, "one_to_one", syn_spec={"receptor_type": 5})
 
-
     wr = nest.Create("weight_recorder")
-    nest.CopyModel("stdp_synapse_sinexp", "my_stdp_synapse_rec", {"weight_recorder": wr, "Wmax":150,"receptor_type": 1,"t_0":150,"Aminus":-0.01,"Aplus":0.0})
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec"}
-    nest.Connect(Gr, PC, syn_spec = syn_spec_dict)
+    nest.CopyModel(
+        "stdp_synapse_sinexp",
+        "my_stdp_synapse_rec",
+        {
+            "weight_recorder": wr,
+            "Wmax": 150,
+            "receptor_type": 1,
+            "t_0": 150,
+            "Aminus": -0.01,
+            "Aplus": 0.0,
+        },
+    )
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec"}
+    nest.Connect(Gr, PC, syn_spec=syn_spec_dict)
 
     # Devices
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    PC_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-
+    PC_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(PC, PC_recorder)
     nest.Connect(Gr, Gr_recorder)
-
-
 
     pf_pc_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
 
@@ -79,10 +136,30 @@ def test_sinexp_kernel():
 
     weight_matrix = reformat_weights(weights)
 
-
-    corrected_cf_tms, cf_evs, corrected_PC_tms, PC_evs, PC_complex_tms, PC_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_PC_tms,
+        PC_evs,
+        PC_complex_tms,
+        PC_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
 
-    plot_synaptic_weight(pf_pc_conns, data, IO, PC, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, TEST_NUMBER)
-
+    plot_synaptic_weight(
+        pf_pc_conns,
+        data,
+        IO,
+        PC,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_PC_tms,
+        PC_evs,
+        TEST_NUMBER,
+    )

--- a/tests/tests_plasticity/test_null_parameters_alpha.py
+++ b/tests/tests_plasticity/test_null_parameters_alpha.py
@@ -1,11 +1,17 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_alpha import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times
+from validation_synapse_alpha import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+)
+
 
 def test_null_parameters_alpha():
     TEST_NUMBER = 8
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -19,12 +25,12 @@ def test_null_parameters_alpha():
 
     N = 3
     M = 5
-    IO = nest.Create("eglif_io_nestml", N) # IO
+    IO = nest.Create("eglif_io_nestml", N)  # IO
     nest.SetStatus(IO, IO_params)
-    MLI = nest.Create("eglif_mli", N) # PC
+    MLI = nest.Create("eglif_mli", N)  # PC
     nest.SetStatus(MLI, MLI_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
     # Decreasing the threshold of GrCs to increase their firing rate
     nest.SetStatus(Gr, {"V_th": -70.0})
@@ -32,22 +38,24 @@ def test_null_parameters_alpha():
     # Connections
     nest.Connect(IO, MLI, "one_to_one", syn_spec={"receptor_type": 3})
 
-
     wr = nest.Create("weight_recorder")
-    nest.CopyModel("stdp_synapse_alpha", "my_stdp_synapse_rec", {"weight_recorder": wr, "Aplus": 0.0, "Aminus": 0.0})
-    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-    nest.Connect(Gr, MLI, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+    nest.CopyModel(
+        "stdp_synapse_alpha",
+        "my_stdp_synapse_rec",
+        {"weight_recorder": wr, "Aplus": 0.0, "Aminus": 0.0},
+    )
+    conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+    nest.Connect(Gr, MLI, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
     # Devices
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    MLI_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+    MLI_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(MLI, MLI_recorder)
     nest.Connect(Gr, Gr_recorder)
-
 
     pf_mli_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
 
@@ -58,10 +66,32 @@ def test_null_parameters_alpha():
 
     weight_matrix = reformat_weights(weights)
 
-    corrected_cf_tms, cf_evs, corrected_MLI_tms, MLI_evs, MLI_complex_tms, MLI_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_MLI_tms,
+        MLI_evs,
+        MLI_complex_tms,
+        MLI_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
 
-    plot_synaptic_weight(pf_mli_conns, data, IO, MLI, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, TEST_NUMBER)
+    plot_synaptic_weight(
+        pf_mli_conns,
+        data,
+        IO,
+        MLI,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_MLI_tms,
+        MLI_evs,
+        TEST_NUMBER,
+    )
 
-    assert (np.all(weight_matrix == 5 ))
+    assert np.all(weight_matrix == 5)

--- a/tests/tests_plasticity/test_null_parameters_sinexp.py
+++ b/tests/tests_plasticity/test_null_parameters_sinexp.py
@@ -1,14 +1,18 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_sinexp import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times
+from validation_synapse_sinexp import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+)
 import sys
-
 
 
 def test_null_parameters_sinexp():
     TEST_NUMBER = 8
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -22,13 +26,12 @@ def test_null_parameters_sinexp():
 
     N = 3
     M = 5
-    IO = nest.Create("eglif_io_nestml", N) # IO
+    IO = nest.Create("eglif_io_nestml", N)  # IO
     nest.SetStatus(IO, IO_params)
-    PC = nest.Create("eglif_pc_nestml", N) # PC
+    PC = nest.Create("eglif_pc_nestml", N)  # PC
     nest.SetStatus(PC, PC_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
-
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
     # Decreasing the threshold of GrCs to increase their firing rate
     nest.SetStatus(Gr, {"V_th": -70.0})
@@ -36,22 +39,24 @@ def test_null_parameters_sinexp():
     # Connections
     nest.Connect(IO, PC, "one_to_one", syn_spec={"receptor_type": 5})
 
-
     wr = nest.Create("weight_recorder")
-    nest.CopyModel("stdp_synapse_sinexp", "my_stdp_synapse_rec", {"weight_recorder": wr, "Aplus": 0.0, "t_0":150, "Aminus": 0.0})
-    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-    nest.Connect(Gr, PC, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+    nest.CopyModel(
+        "stdp_synapse_sinexp",
+        "my_stdp_synapse_rec",
+        {"weight_recorder": wr, "Aplus": 0.0, "t_0": 150, "Aminus": 0.0},
+    )
+    conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+    nest.Connect(Gr, PC, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
     # Devices
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    PC_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+    PC_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(PC, PC_recorder)
     nest.Connect(Gr, Gr_recorder)
-
 
     pf_pc_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
 
@@ -62,10 +67,32 @@ def test_null_parameters_sinexp():
 
     weight_matrix = reformat_weights(weights)
 
-    corrected_cf_tms, cf_evs, corrected_PC_tms, PC_evs, PC_complex_tms, PC_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_PC_tms,
+        PC_evs,
+        PC_complex_tms,
+        PC_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
 
-    plot_synaptic_weight(pf_pc_conns, data, IO, PC, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, TEST_NUMBER)
+    plot_synaptic_weight(
+        pf_pc_conns,
+        data,
+        IO,
+        PC,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_PC_tms,
+        PC_evs,
+        TEST_NUMBER,
+    )
 
-    assert (np.all(weight_matrix == 0.14 ))
+    assert np.all(weight_matrix == 0.14)

--- a/tests/tests_plasticity/test_offset_encoding_alpha.py
+++ b/tests/tests_plasticity/test_offset_encoding_alpha.py
@@ -1,12 +1,17 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_alpha import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times
+from validation_synapse_alpha import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+)
 import sys
 
 
 def test_offset_encoding_alpha():
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -18,43 +23,45 @@ def test_offset_encoding_alpha():
     M = 5
 
     for trial in range(N):
-        TEST_NUMBER = 5 + trial/10
+        TEST_NUMBER = 5 + trial / 10
         nest.ResetKernel()
         nest.Install("custom_stdp_module")
         nest.SetKernelStatus({"resolution": 0.1})
 
         # Create the network and tune parameters
-        IO = nest.Create("eglif_io_nestml", N) # IO
+        IO = nest.Create("eglif_io_nestml", N)  # IO
         nest.SetStatus(IO, IO_params)
-        MLI = nest.Create("eglif_mli", N) # PC
+        MLI = nest.Create("eglif_mli", N)  # PC
         nest.SetStatus(MLI, MLI_params)
-        Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-        #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+        Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+        # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
-        nest.SetStatus(Gr, {"V_th": -70.0}) # Increase firing of GrCs
+        nest.SetStatus(Gr, {"V_th": -70.0})  # Increase firing of GrCs
 
         # "Deactivate" two out of three PCs
         for idx, cell in enumerate(IO):
             if idx != trial:
-                nest.SetStatus(cell, {"V_th":0.0})
-        
+                nest.SetStatus(cell, {"V_th": 0.0})
+
         # Connections
         nest.Connect(IO, MLI, "one_to_one", syn_spec={"receptor_type": 3})
-    
-        wr = nest.Create("weight_recorder")
-        nest.CopyModel("stdp_synapse_alpha", "my_stdp_synapse_rec", {"weight_recorder": wr})
 
-        conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-        syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-        nest.Connect(Gr, MLI, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+        wr = nest.Create("weight_recorder")
+        nest.CopyModel(
+            "stdp_synapse_alpha", "my_stdp_synapse_rec", {"weight_recorder": wr}
+        )
+
+        conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+        syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+        nest.Connect(Gr, MLI, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
         pf_mli_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
-        IO_mli_conns = nest.GetConnections(source = IO, target = MLI)
+        IO_mli_conns = nest.GetConnections(source=IO, target=MLI)
 
-        # Devices   
+        # Devices
         cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-        MLI_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-        Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+        MLI_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+        Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
         nest.Connect(IO, cf_recorder)
         nest.Connect(MLI, MLI_recorder)
@@ -67,20 +74,48 @@ def test_offset_encoding_alpha():
             weights.append(nest.GetStatus(pf_mli_conns, "weight"))
 
         weight_matrix = reformat_weights(weights)
-        
-        corrected_cf_tms, cf_evs, corrected_MLI_tms, MLI_evs, MLI_complex_tms, MLI_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
+
+        (
+            corrected_cf_tms,
+            cf_evs,
+            corrected_MLI_tms,
+            MLI_evs,
+            MLI_complex_tms,
+            MLI_complex_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+        ) = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
 
         data = nest.GetStatus(wr)[0]
 
-        plot_synaptic_weight(pf_mli_conns, data, IO, MLI, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, TEST_NUMBER) 
+        plot_synaptic_weight(
+            pf_mli_conns,
+            data,
+            IO,
+            MLI,
+            Gr,
+            corrected_cf_tms,
+            cf_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+            corrected_MLI_tms,
+            MLI_evs,
+            TEST_NUMBER,
+        )
 
         # Filter connections
-        matching_conn = nest.GetConnections(source = IO[trial], target = MLI)
+        matching_conn = nest.GetConnections(source=IO[trial], target=MLI)
         corresponding_PC = matching_conn.get("target")
 
         # Find the plastic connections involving the "stimulated" PC
-        plastic_connections = nest.GetConnections(synapse_model = "my_stdp_synapse_rec", source = Gr, target = MLI[corresponding_PC - N - 1])
+        plastic_connections = nest.GetConnections(
+            synapse_model="my_stdp_synapse_rec",
+            source=Gr,
+            target=MLI[corresponding_PC - N - 1],
+        )
 
         for idx, connection in enumerate(pf_mli_conns):
             if connection not in plastic_connections:
-                assert np.all(np.diff(weight_matrix[idx, :]) <= 0) # Make sure LTP is not happening 
+                assert np.all(
+                    np.diff(weight_matrix[idx, :]) <= 0
+                )  # Make sure LTP is not happening

--- a/tests/tests_plasticity/test_offset_encoding_sinexp.py
+++ b/tests/tests_plasticity/test_offset_encoding_sinexp.py
@@ -1,13 +1,17 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_sinexp import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times
+from validation_synapse_sinexp import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+)
 import sys
 
 
-
 def test_offset_encoding_sinexp():
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -19,44 +23,47 @@ def test_offset_encoding_sinexp():
     M = 5
 
     for trial in range(N):
-        TEST_NUMBER = 5 + trial/10
+        TEST_NUMBER = 5 + trial / 10
         nest.ResetKernel()
         nest.Install("custom_stdp_module")
         nest.SetKernelStatus({"resolution": 0.1})
 
         # Create the network and tune parameters
-        IO = nest.Create("eglif_io_nestml", N) # IO
+        IO = nest.Create("eglif_io_nestml", N)  # IO
         nest.SetStatus(IO, IO_params)
-        PC = nest.Create("eglif_pc_nestml", N) # PC
+        PC = nest.Create("eglif_pc_nestml", N)  # PC
         nest.SetStatus(PC, PC_params)
-        Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-        #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+        Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+        # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
-        nest.SetStatus(Gr, {"V_th": -71.0}) # Increase firing of GrCs
+        nest.SetStatus(Gr, {"V_th": -71.0})  # Increase firing of GrCs
 
         # "Deactivate" two out of three PCs
         for idx, cell in enumerate(IO):
             if idx != trial:
-                nest.SetStatus(cell, {"V_th":0.0})
-        
+                nest.SetStatus(cell, {"V_th": 0.0})
+
         # Connections
         nest.Connect(IO, PC, "one_to_one", syn_spec={"receptor_type": 5})
 
-
         wr = nest.Create("weight_recorder")
-        nest.CopyModel("stdp_synapse_sinexp", "my_stdp_synapse_rec", {"weight_recorder": wr,"t_0":150,  "Aplus":0.001})
+        nest.CopyModel(
+            "stdp_synapse_sinexp",
+            "my_stdp_synapse_rec",
+            {"weight_recorder": wr, "t_0": 150, "Aplus": 0.001},
+        )
 
-        conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-        syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-        nest.Connect(Gr, PC, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+        conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+        syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+        nest.Connect(Gr, PC, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
         pf_pc_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
-        IO_pc_conns = nest.GetConnections(source = IO, target = PC)
+        IO_pc_conns = nest.GetConnections(source=IO, target=PC)
 
-        # Devices   
+        # Devices
         cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-        PC_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-        Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+        PC_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+        Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
         nest.Connect(IO, cf_recorder)
         nest.Connect(PC, PC_recorder)
@@ -69,21 +76,48 @@ def test_offset_encoding_sinexp():
             weights.append(nest.GetStatus(pf_pc_conns, "weight"))
 
         weight_matrix = reformat_weights(weights)
-        
-        corrected_cf_tms, cf_evs, corrected_PC_tms, PC_evs, PC_complex_tms, PC_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
+
+        (
+            corrected_cf_tms,
+            cf_evs,
+            corrected_PC_tms,
+            PC_evs,
+            PC_complex_tms,
+            PC_complex_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+        ) = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
 
         data = nest.GetStatus(wr)[0]
 
-        plot_synaptic_weight(pf_pc_conns, data, IO, PC, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, TEST_NUMBER) 
+        plot_synaptic_weight(
+            pf_pc_conns,
+            data,
+            IO,
+            PC,
+            Gr,
+            corrected_cf_tms,
+            cf_evs,
+            corrected_gr_spikes,
+            Gr_evs,
+            corrected_PC_tms,
+            PC_evs,
+            TEST_NUMBER,
+        )
 
         # Filter connections
-        matching_conn = nest.GetConnections(source = IO[trial], target = PC)
+        matching_conn = nest.GetConnections(source=IO[trial], target=PC)
         corresponding_PC = matching_conn.get("target")
 
         # Find the plastic connections involving the "stimulated" PC
-        plastic_connections = nest.GetConnections(synapse_model = "my_stdp_synapse_rec", source = Gr, target = PC[corresponding_PC - N - 1])
+        plastic_connections = nest.GetConnections(
+            synapse_model="my_stdp_synapse_rec",
+            source=Gr,
+            target=PC[corresponding_PC - N - 1],
+        )
 
         for idx, connection in enumerate(pf_pc_conns):
             if connection not in plastic_connections:
-                assert np.all(np.diff(weight_matrix[idx, :]) >= 0) # Make sure LTD is not happening 
-
+                assert np.all(
+                    np.diff(weight_matrix[idx, :]) >= 0
+                )  # Make sure LTD is not happening

--- a/tests/tests_plasticity/test_silent_GrC_alpha.py
+++ b/tests/tests_plasticity/test_silent_GrC_alpha.py
@@ -1,11 +1,17 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_alpha import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times
+from validation_synapse_alpha import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+)
+
 
 def test_silent_GrC_alpha():
     TEST_NUMBER = 2
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -19,34 +25,30 @@ def test_silent_GrC_alpha():
 
     N = 3
     M = 5
-    IO = nest.Create("eglif_io_nestml", N) # IO
+    IO = nest.Create("eglif_io_nestml", N)  # IO
     nest.SetStatus(IO, IO_params)
-    MLI = nest.Create("eglif_mli", N) # PC
+    MLI = nest.Create("eglif_mli", N)  # PC
     nest.SetStatus(MLI, MLI_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    nest.SetStatus(Gr, GR_params)  # If used, Gr does not spike
 
     # Connections
     nest.Connect(IO, MLI, "one_to_one", syn_spec={"receptor_type": 3})
 
-
     wr = nest.Create("weight_recorder")
     nest.CopyModel("stdp_synapse_alpha", "my_stdp_synapse_rec", {"weight_recorder": wr})
-    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-    nest.Connect(Gr, MLI, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
-
+    conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+    nest.Connect(Gr, MLI, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
     # Devices
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    MLI_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+    MLI_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(MLI, MLI_recorder)
     nest.Connect(Gr, Gr_recorder)
-
-
 
     pf_mli_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
 
@@ -57,10 +59,33 @@ def test_silent_GrC_alpha():
 
     weight_matrix = reformat_weights(weights)
 
-    corrected_cf_tms, cf_evs, corrected_MLI_tms, MLI_evs, MLI_complex_tms, MLI_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_MLI_tms,
+        MLI_evs,
+        MLI_complex_tms,
+        MLI_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
 
-    plot_synaptic_matrix(pf_mli_conns, data, weight_matrix, IO, MLI, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, TEST_NUMBER)
-    #print(weight_matrix)
-    assert (np.all(weight_matrix == 5 ))
+    plot_synaptic_matrix(
+        pf_mli_conns,
+        data,
+        weight_matrix,
+        IO,
+        MLI,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_MLI_tms,
+        MLI_evs,
+        TEST_NUMBER,
+    )
+    # print(weight_matrix)
+    assert np.all(weight_matrix == 5)

--- a/tests/tests_plasticity/test_silent_GrC_sinexp.py
+++ b/tests/tests_plasticity/test_silent_GrC_sinexp.py
@@ -1,12 +1,17 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_sinexp import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, correct_spike_times
+from validation_synapse_sinexp import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    correct_spike_times,
+)
 
 
 def test_silent_GrC_sinexp():
     TEST_NUMBER = 2
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -20,34 +25,34 @@ def test_silent_GrC_sinexp():
 
     N = 3
     M = 5
-    IO = nest.Create("eglif_io_nestml", N) # IO
+    IO = nest.Create("eglif_io_nestml", N)  # IO
     nest.SetStatus(IO, IO_params)
-    PC = nest.Create("eglif_pc_nestml", N) # PC
+    PC = nest.Create("eglif_pc_nestml", N)  # PC
     nest.SetStatus(PC, PC_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    nest.SetStatus(Gr, GR_params)  # If used, Gr does not spike
 
     # Connections
     nest.Connect(IO, PC, "one_to_one", syn_spec={"receptor_type": 5})
 
-
     wr = nest.Create("weight_recorder")
-    nest.CopyModel("stdp_synapse_sinexp", "my_stdp_synapse_rec", {"weight_recorder": wr,"t_0":150})
-    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-    nest.Connect(Gr, PC, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
-
+    nest.CopyModel(
+        "stdp_synapse_sinexp",
+        "my_stdp_synapse_rec",
+        {"weight_recorder": wr, "t_0": 150},
+    )
+    conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+    nest.Connect(Gr, PC, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
     # Devices
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    PC_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+    PC_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(PC, PC_recorder)
     nest.Connect(Gr, Gr_recorder)
-
-
 
     pf_pc_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
 
@@ -58,9 +63,32 @@ def test_silent_GrC_sinexp():
 
     weight_matrix = reformat_weights(weights)
 
-    corrected_cf_tms, cf_evs, corrected_PC_tms, PC_evs, PC_complex_tms, PC_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_PC_tms,
+        PC_evs,
+        PC_complex_tms,
+        PC_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
 
-    plot_synaptic_matrix(pf_pc_conns, data, weight_matrix, IO, PC, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, TEST_NUMBER)
-    assert (np.all(weight_matrix == 0.14 ))
+    plot_synaptic_matrix(
+        pf_pc_conns,
+        data,
+        weight_matrix,
+        IO,
+        PC,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_PC_tms,
+        PC_evs,
+        TEST_NUMBER,
+    )
+    assert np.all(weight_matrix == 0.14)

--- a/tests/tests_plasticity/test_simple_Gr_spike_alpha.py
+++ b/tests/tests_plasticity/test_simple_Gr_spike_alpha.py
@@ -1,14 +1,19 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_alpha import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, plot_simple_spike, correct_spike_times
+from validation_synapse_alpha import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    plot_simple_spike,
+    correct_spike_times,
+)
 import sys
-
 
 
 def test_simple_Gr_spike_alpha():
     TEST_NUMBER = 3
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -22,38 +27,39 @@ def test_simple_Gr_spike_alpha():
 
     N = 3
     M = 5
-    IO = nest.Create("eglif_io_nestml", N) # IO
+    IO = nest.Create("eglif_io_nestml", N)  # IO
     nest.SetStatus(IO, IO_params)
-    MLI = nest.Create("eglif_mli", N) # PC
+    MLI = nest.Create("eglif_mli", N)  # PC
     nest.SetStatus(MLI, MLI_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
     simple_spike = nest.Create("spike_generator", M, {"spike_times": [998.0]})
-    nest.Connect(simple_spike, Gr, "one_to_one", syn_spec={"receptor_type": 1, "weight":1000.0})
+    nest.Connect(
+        simple_spike, Gr, "one_to_one", syn_spec={"receptor_type": 1, "weight": 1000.0}
+    )
 
     # Set threshold of GrCs to 0.0 mV to avoid autonomous firing
     nest.SetStatus(Gr, {"V_th": 0.0})
 
     # Connections
     nest.Connect(IO, MLI, "one_to_one", syn_spec={"receptor_type": 3})
-    #nest.Connect(IO, Gr, "all_to_all", syn_spec={"receptor_type": 5})
+    # nest.Connect(IO, Gr, "all_to_all", syn_spec={"receptor_type": 5})
 
     wr = nest.Create("weight_recorder")
     nest.CopyModel("stdp_synapse_alpha", "my_stdp_synapse_rec", {"weight_recorder": wr})
-    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-    nest.Connect(Gr, MLI, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+    conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+    nest.Connect(Gr, MLI, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
     # Devices
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    MLI_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+    MLI_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(MLI, MLI_recorder)
     nest.Connect(Gr, Gr_recorder)
-
 
     pf_mli_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
 
@@ -64,10 +70,33 @@ def test_simple_Gr_spike_alpha():
 
     weight_matrix = reformat_weights(weights)
 
-    corrected_cf_tms, cf_evs, corrected_MLI_tms, MLI_evs, MLI_complex_tms, MLI_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_MLI_tms,
+        MLI_evs,
+        MLI_complex_tms,
+        MLI_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
 
-    plot_simple_spike(pf_mli_conns, data, weight_matrix, IO, MLI, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, TEST_NUMBER)
+    plot_simple_spike(
+        pf_mli_conns,
+        data,
+        weight_matrix,
+        IO,
+        MLI,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_MLI_tms,
+        MLI_evs,
+        TEST_NUMBER,
+    )
 
-    assert (np.all(weight_matrix == 5 ))
+    assert np.all(weight_matrix == 5)

--- a/tests/tests_plasticity/test_simple_Gr_spike_sinexp.py
+++ b/tests/tests_plasticity/test_simple_Gr_spike_sinexp.py
@@ -1,12 +1,18 @@
 import nest
 import numpy as np
 import json
-from validation_synapse_sinexp import plot_synaptic_weight, reformat_weights, plot_synaptic_matrix, plot_simple_spike, correct_spike_times
+from validation_synapse_sinexp import (
+    plot_synaptic_weight,
+    reformat_weights,
+    plot_synaptic_matrix,
+    plot_simple_spike,
+    correct_spike_times,
+)
 
 
 def test_simple_Gr_spike_sinexp():
     TEST_NUMBER = 3
-    f = open('tests_plasticity/eglif_params.json')
+    f = open("tests_plasticity/eglif_params.json")
     params = json.load(f)
     f.close()
 
@@ -20,16 +26,17 @@ def test_simple_Gr_spike_sinexp():
 
     N = 3
     M = 5
-    IO = nest.Create("eglif_io_nestml", N) # IO
+    IO = nest.Create("eglif_io_nestml", N)  # IO
     nest.SetStatus(IO, IO_params)
-    PC = nest.Create("eglif_pc_nestml", N) # PC
+    PC = nest.Create("eglif_pc_nestml", N)  # PC
     nest.SetStatus(PC, PC_params)
-    Gr = nest.Create("eglif_cond_alpha_multisyn", M) # Gr
-    #nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
+    Gr = nest.Create("eglif_cond_alpha_multisyn", M)  # Gr
+    # nest.SetStatus(Gr, GR_params) # If used, Gr does not spike
 
     simple_spike = nest.Create("spike_generator", M, {"spike_times": [998.0]})
-    nest.Connect(simple_spike, Gr, "one_to_one", syn_spec={"receptor_type": 1, "weight":1000.0})
-
+    nest.Connect(
+        simple_spike, Gr, "one_to_one", syn_spec={"receptor_type": 1, "weight": 1000.0}
+    )
 
     # Set threshold of GrCs to 0.0 mV to avoid autonomous firing
     nest.SetStatus(Gr, {"V_th": 0.0})
@@ -37,22 +44,24 @@ def test_simple_Gr_spike_sinexp():
     # Connections
     nest.Connect(IO, PC, "one_to_one", syn_spec={"receptor_type": 5})
 
-
     wr = nest.Create("weight_recorder")
-    nest.CopyModel("stdp_synapse_sinexp", "my_stdp_synapse_rec", {"weight_recorder": wr,"t_0":150})
-    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 4}
-    syn_spec_dict = {'synapse_model': "my_stdp_synapse_rec", "receptor_type": 1}
-    nest.Connect(Gr, PC, conn_spec = conn_spec_dict, syn_spec = syn_spec_dict)
+    nest.CopyModel(
+        "stdp_synapse_sinexp",
+        "my_stdp_synapse_rec",
+        {"weight_recorder": wr, "t_0": 150},
+    )
+    conn_spec_dict = {"rule": "fixed_indegree", "indegree": 4}
+    syn_spec_dict = {"synapse_model": "my_stdp_synapse_rec", "receptor_type": 1}
+    nest.Connect(Gr, PC, conn_spec=conn_spec_dict, syn_spec=syn_spec_dict)
 
     # Devices
     cf_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
-    PC_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
-    Gr_recorder = nest.Create("spike_recorder",  {"record_to": "memory"})
+    PC_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
+    Gr_recorder = nest.Create("spike_recorder", {"record_to": "memory"})
 
     nest.Connect(IO, cf_recorder)
     nest.Connect(PC, PC_recorder)
     nest.Connect(Gr, Gr_recorder)
-
 
     pf_pc_conns = nest.GetConnections(synapse_model="my_stdp_synapse_rec")
 
@@ -63,9 +72,32 @@ def test_simple_Gr_spike_sinexp():
 
     weight_matrix = reformat_weights(weights)
 
-    corrected_cf_tms, cf_evs, corrected_PC_tms, PC_evs, PC_complex_tms, PC_complex_evs, corrected_gr_spikes, Gr_evs = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
+    (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_PC_tms,
+        PC_evs,
+        PC_complex_tms,
+        PC_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    ) = correct_spike_times(cf_recorder, PC_recorder, Gr_recorder)
 
     data = nest.GetStatus(wr)[0]
 
-    plot_simple_spike(pf_pc_conns, data, weight_matrix, IO, PC, Gr, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, TEST_NUMBER)
-    assert (np.all(weight_matrix == 0.14 ))
+    plot_simple_spike(
+        pf_pc_conns,
+        data,
+        weight_matrix,
+        IO,
+        PC,
+        Gr,
+        corrected_cf_tms,
+        cf_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+        corrected_PC_tms,
+        PC_evs,
+        TEST_NUMBER,
+    )
+    assert np.all(weight_matrix == 0.14)

--- a/tests/tests_plasticity/validation_synapse_alpha.py
+++ b/tests/tests_plasticity/validation_synapse_alpha.py
@@ -5,126 +5,180 @@ import os
 import math
 from scipy.interpolate import interp1d
 
-def plot_synaptic_weight(pf_mli_conns, data, IO, MLI, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, test_n):
-    senders = data['events']['senders']
-    targets = data['events']['targets']
-    weights = data['events']['weights']
-    
-    
+
+def plot_synaptic_weight(
+    pf_mli_conns,
+    data,
+    IO,
+    MLI,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_MLI_tms,
+    MLI_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    weights = data["events"]["weights"]
+
     for conn in pf_mli_conns:
-        #print(conn)
+        # print(conn)
         N = len(MLI)
         source_id = conn.get("source")
         target_id = conn.get("target")
-        #print("source_id: ", source_id)
-        #print("starget_id: ", target_id)
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
 
         indices = np.where((senders == source_id) & (targets == target_id))
         result_weights = weights[indices]
         print(result_weights)
 
         # Find IO corresponding to MLI
-        connection = nest.GetConnections(source = IO, target = MLI[target_id - N-1])
+        connection = nest.GetConnections(source=IO, target=MLI[target_id - N - 1])
         IO_sender = connection.get("source")
-        #print("Corresponding IO: ", IO_sender)
-        
+        # print("Corresponding IO: ", IO_sender)
+
         # Get the spikes of IO, Gr and MLI
         IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-        #print("IO spikes: ", IO_times)
-        
-        total_MLI_times = [t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id]
-        complex_MLI_times = [t for t in total_MLI_times if t-1.0 in IO_times]
+        # print("IO spikes: ", IO_times)
+
+        total_MLI_times = [
+            t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id
+        ]
+        complex_MLI_times = [t for t in total_MLI_times if t - 1.0 in IO_times]
         simple_MLI_times = [t for t in total_MLI_times if t not in complex_MLI_times]
-        #print("MLI simple spikes: ", simple_MLI_times)
-        #print("MLI complex spikes: ", complex_MLI_times)
+        # print("MLI simple spikes: ", simple_MLI_times)
+        # print("MLI complex spikes: ", complex_MLI_times)
 
-        total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
-        #complex_Gr_times = [t for t in total_Gr_times if t in complex_MLI_times]
-        simple_Gr_times = [t for t in total_Gr_times ]
-        #print("Simple Gr spikes: ", simple_Gr_times)
-        #print("Complex Gr spikes: ", complex_Gr_times)
-        #assert(simple_Gr_times)
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
+        # complex_Gr_times = [t for t in total_Gr_times if t in complex_MLI_times]
+        simple_Gr_times = [t for t in total_Gr_times]
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
 
-        
-
-    
-
-        fig, ax = plt.subplots(2,1)
-        ax[0].plot(data["events"]["times"][indices], result_weights, '--')
-        #print(data["events"]["times"][indices])
-        #print(result_weights)
+        fig, ax = plt.subplots(2, 1)
+        ax[0].plot(data["events"]["times"][indices], result_weights, "--")
+        # print(data["events"]["times"][indices])
+        # print(result_weights)
         ax[0].set_ylabel("Synaptic weight")
 
-        ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-        ax[1].scatter(simple_MLI_times, target_id*np.ones(len(simple_MLI_times)), label='MLI')
-        ax[1].scatter(complex_MLI_times, target_id*np.ones(len(complex_MLI_times)), color="red", label='Complex spikes')
-        ax[1].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
-        #ax[1].scatter(complex_MLI_times, source_id*np.ones(len(complex_MLI_times)), color = "white")
-        ax[1].legend(fontsize='small')
+        ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+        ax[1].scatter(
+            simple_MLI_times, target_id * np.ones(len(simple_MLI_times)), label="MLI"
+        )
+        ax[1].scatter(
+            complex_MLI_times,
+            target_id * np.ones(len(complex_MLI_times)),
+            color="red",
+            label="Complex spikes",
+        )
+        ax[1].scatter(
+            simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+        )
+        # ax[1].scatter(complex_MLI_times, source_id*np.ones(len(complex_MLI_times)), color = "white")
+        ax[1].legend(fontsize="small")
         ax[1].set_ylim(0, 20)
         ax[1].set_xlabel("Time [ms]")
         ax[1].set_ylabel("Neuron gID")
 
-        subplot_labels = ['A', 'B']
+        subplot_labels = ["A", "B"]
         for i, axs in enumerate(ax):
-            axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                fontsize=16, fontweight='bold', va='top', ha='right')
-            ax[i].spines['top'].set_visible(False)
-            ax[i].spines['right'].set_visible(False)
-            ax[i].spines['bottom'].set_visible(True)
-            ax[i].spines['left'].set_visible(True)
-
+            axs.text(
+                -0.1,
+                1.1,
+                subplot_labels[i],
+                transform=axs.transAxes,
+                fontsize=16,
+                fontweight="bold",
+                va="top",
+                ha="right",
+            )
+            ax[i].spines["top"].set_visible(False)
+            ax[i].spines["right"].set_visible(False)
+            ax[i].spines["bottom"].set_visible(True)
+            ax[i].spines["left"].set_visible(True)
 
         directory = f"figures_plasticity_alpha/test_{test_n}"
         filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
         os.makedirs(directory, exist_ok=True)
         plt.tight_layout()
         plt.savefig(filename)
-        
 
         if test_n == 9:
             fig, ax = plt.subplots(3, 1, figsize=(8, 10), sharex=False)
-            
+
             # --- 1. Synaptic weight trace over time ---
-            ax[0].plot(data["events"]["times"][indices], result_weights, '*--', label='Synaptic Weight')
+            ax[0].plot(
+                data["events"]["times"][indices],
+                result_weights,
+                "*--",
+                label="Synaptic Weight",
+            )
             ax[0].set_ylabel("Synaptic weight", fontsize=12)
             ax[0].legend()
 
             # --- 2. Spike raster ---
-            ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[1].scatter(simple_MLI_times, target_id*np.ones(len(simple_MLI_times)), label='MLI')
-            ax[1].scatter(complex_MLI_times, target_id*np.ones(len(complex_MLI_times)), color="red", label='Complex spikes')
-            ax[1].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
+            ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+            ax[1].scatter(
+                simple_MLI_times,
+                target_id * np.ones(len(simple_MLI_times)),
+                label="MLI",
+            )
+            ax[1].scatter(
+                complex_MLI_times,
+                target_id * np.ones(len(complex_MLI_times)),
+                color="red",
+                label="Complex spikes",
+            )
+            ax[1].scatter(
+                simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+            )
 
             ax[1].set_ylim(0, 5)
             ax[1].set_xlabel("Time [ms]", fontsize=12)
             ax[1].set_ylabel("Neuron gID", fontsize=12)
-            ax[1].legend(fontsize='small')
+            ax[1].legend(fontsize="small")
 
             # --- 3. LTP amount vs spike time difference ---
             diffs = np.diff(result_weights)
-            LTP_mask = diffs > 0  
+            LTP_mask = diffs > 0
 
             # Define a Δt window from -200 ms to 0 ms
-            spike_time_diffs = np.linspace(-200, 0, len(diffs))  # Assuming uniform mapping
+            spike_time_diffs = np.linspace(
+                -200, 0, len(diffs)
+            )  # Assuming uniform mapping
             LTP_values = diffs[LTP_mask]  # Make LTP amounts positive
             LTP_times = spike_time_diffs[LTP_mask]
 
-            ax[2].plot(LTP_times, LTP_values, 'o-', color='black')
-            ax[2].set_ylabel('LTP amount', fontsize=12)
-            ax[2].set_xlabel('Spike time difference [ms]', fontsize=12)
+            ax[2].plot(LTP_times, LTP_values, "o-", color="black")
+            ax[2].set_ylabel("LTP amount", fontsize=12)
+            ax[2].set_xlabel("Spike time difference [ms]", fontsize=12)
             ax[2].set_xticks(np.arange(-200, 1, 20))
             ax[2].set_xlim([-200, 0])
 
             # --- Consistent formatting for all subplots ---
-            subplot_labels = ['A', 'B', 'C']
+            subplot_labels = ["A", "B", "C"]
             for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                        fontsize=16, fontweight='bold', va='top', ha='right')
-                axs.spines['top'].set_visible(False)
-                axs.spines['right'].set_visible(False)
-                axs.spines['bottom'].set_visible(True)
-                axs.spines['left'].set_visible(True)
+                axs.text(
+                    -0.1,
+                    1.1,
+                    subplot_labels[i],
+                    transform=axs.transAxes,
+                    fontsize=16,
+                    fontweight="bold",
+                    va="top",
+                    ha="right",
+                )
+                axs.spines["top"].set_visible(False)
+                axs.spines["right"].set_visible(False)
+                axs.spines["bottom"].set_visible(True)
+                axs.spines["left"].set_visible(True)
 
             # --- Save figure ---
             filename = f"{directory}/LTP_LTD.png"
@@ -132,56 +186,72 @@ def plot_synaptic_weight(pf_mli_conns, data, IO, MLI, GrC, corrected_cf_tms, cf_
             plt.tight_layout()
             plt.savefig(filename)
 
-            
 
-def plot_LTP(pf_mli_conns, data, weight_matrix, IO, MLI, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, test_n):
-    senders = data['events']['senders']
-    targets = data['events']['targets']
-    weights = data['events']['weights']
-    #print(data['events'])
+def plot_LTP(
+    pf_mli_conns,
+    data,
+    weight_matrix,
+    IO,
+    MLI,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_MLI_tms,
+    MLI_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    weights = data["events"]["weights"]
+    # print(data['events'])
     for idx, conn in enumerate(pf_mli_conns):
-        #print(conn)
+        # print(conn)
         N = len(MLI)
         source_id = conn.get("source")
         target_id = conn.get("target")
-        #print("source_id: ", source_id)
-        #print("starget_id: ", target_id)
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
 
         indices = np.where((senders == source_id) & (targets == target_id))
         result_weights = weights[indices]
 
         # Find IO corresponding to MLI
-        connection = nest.GetConnections(source = IO, target = MLI[target_id - N-1])
+        connection = nest.GetConnections(source=IO, target=MLI[target_id - N - 1])
         IO_sender = connection.get("source")
-        #print("Corresponding IO: ", IO_sender)
-        
+        # print("Corresponding IO: ", IO_sender)
+
         # Get the spikes of IO, Gr and MLI
         IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-        #print("IO spikes: ", IO_times)
-        
-        total_MLI_times = [t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id]
-        complex_MLI_times = [t for t in total_MLI_times if t-1.0 in IO_times]
+        # print("IO spikes: ", IO_times)
+
+        total_MLI_times = [
+            t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id
+        ]
+        complex_MLI_times = [t for t in total_MLI_times if t - 1.0 in IO_times]
         simple_MLI_times = [t for t in total_MLI_times if t not in complex_MLI_times]
-        #print("MLI simple spikes: ", simple_MLI_times)
-        #print("MLI complex spikes: ", complex_MLI_times)
+        # print("MLI simple spikes: ", simple_MLI_times)
+        # print("MLI complex spikes: ", complex_MLI_times)
 
         first_complex_spike = complex_MLI_times[0]
         print(first_complex_spike)
-        first_complex_step = int(first_complex_spike/0.1)
+        first_complex_step = int(first_complex_spike / 0.1)
         print(first_complex_step)
-        total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
         complex_Gr_times = [t for t in total_Gr_times if t in complex_MLI_times]
         simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
-        #print("Simple Gr spikes: ", simple_Gr_times)
-        #print("Complex Gr spikes: ", complex_Gr_times)
-        #assert(simple_Gr_times)
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
 
         result_weights = weight_matrix[idx, :]
 
         print(type(data["events"]["times"][indices]))
         LTP_indices = np.where(data["events"]["times"][indices] < first_complex_spike)
         print(type(LTP_indices))
- 
 
         print(type(simple_MLI_times))
         simple_MLI_times = np.array(simple_MLI_times)
@@ -194,44 +264,66 @@ def plot_LTP(pf_mli_conns, data, weight_matrix, IO, MLI, GrC, corrected_cf_tms, 
         simple_Gr_times = simple_Gr_times[simple_Gr_indices]
 
         # Plot weight and spikes
-        fig, ax = plt.subplots(3,1, sharex = True, figsize =(8,6))
+        fig, ax = plt.subplots(3, 1, sharex=True, figsize=(8, 6))
 
         default_colors = plt.cm.tab10.colors
         green_color = default_colors[2]
-        #ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-        ax[0].scatter(simple_MLI_times[:4], target_id*np.ones(len(simple_MLI_times))[:4], label='MLI', color ="orange")
-        #ax[1].scatter(complex_MLI_times, target_id*np.ones(len(complex_MLI_times)), color="red", label='Complex spikes')
-        ax[0].scatter(simple_Gr_times[:4], source_id*np.ones(len(simple_Gr_times))[:4], label='GrCs', color =green_color)
-        #ax[1].scatter(complex_MLI_times, source_id*np.ones(len(complex_MLI_times)), color = "white")
-        ax[0].legend(fontsize='small')
+        # ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
+        ax[0].scatter(
+            simple_MLI_times[:4],
+            target_id * np.ones(len(simple_MLI_times))[:4],
+            label="MLI",
+            color="orange",
+        )
+        # ax[1].scatter(complex_MLI_times, target_id*np.ones(len(complex_MLI_times)), color="red", label='Complex spikes')
+        ax[0].scatter(
+            simple_Gr_times[:4],
+            source_id * np.ones(len(simple_Gr_times))[:4],
+            label="GrCs",
+            color=green_color,
+        )
+        # ax[1].scatter(complex_MLI_times, source_id*np.ones(len(complex_MLI_times)), color = "white")
+        ax[0].legend(fontsize="small")
         ax[0].set_ylim(0, 20)
-        #ax[0].set_xlim(0, first_complex_spike-5)
+        # ax[0].set_xlim(0, first_complex_spike-5)
         ax[0].set_xlabel("Time [ms]")
         ax[0].set_ylabel("Neuron gID")
         ax[0].tick_params(labelbottom=True)
-        
-        ax[1].plot(np.arange(math.ceil(first_complex_spike-5)), result_weights[:math.ceil(first_complex_spike-5)])
+
+        ax[1].plot(
+            np.arange(math.ceil(first_complex_spike - 5)),
+            result_weights[: math.ceil(first_complex_spike - 5)],
+        )
         ax[1].set_ylabel("Synaptic weight")
         ax[1].set_xlabel("Time [ms]")
 
         ax[1].tick_params(labelbottom=True)
-        
-        ax[2].plot(np.arange(math.ceil(first_complex_spike-5))[1:], np.diff(result_weights[:math.ceil(first_complex_spike-5)]), 'k--')
+
+        ax[2].plot(
+            np.arange(math.ceil(first_complex_spike - 5))[1:],
+            np.diff(result_weights[: math.ceil(first_complex_spike - 5)]),
+            "k--",
+        )
         ax[2].set_ylabel("Diff weight")
-        ax[2].set_ylim((-1.7,1.2))
+        ax[2].set_ylim((-1.7, 1.2))
         ax[2].set_xlabel("Time [ms]")
-        
 
-            
-        subplot_labels = ['A', 'B', 'C']
+        subplot_labels = ["A", "B", "C"]
         for i, axs in enumerate(ax):
-            axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                fontsize=16, fontweight='bold', va='top', ha='right')
-            ax[i].spines['top'].set_visible(False)
-            ax[i].spines['right'].set_visible(False)
-            ax[i].spines['bottom'].set_visible(True)
-            ax[i].spines['left'].set_visible(True)
-
+            axs.text(
+                -0.1,
+                1.1,
+                subplot_labels[i],
+                transform=axs.transAxes,
+                fontsize=16,
+                fontweight="bold",
+                va="top",
+                ha="right",
+            )
+            ax[i].spines["top"].set_visible(False)
+            ax[i].spines["right"].set_visible(False)
+            ax[i].spines["bottom"].set_visible(True)
+            ax[i].spines["left"].set_visible(True)
 
         directory = f"figures_plasticity_alpha/test_{test_n}"
         filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}_LTP.png"
@@ -241,178 +333,256 @@ def plot_LTP(pf_mli_conns, data, weight_matrix, IO, MLI, GrC, corrected_cf_tms, 
         plt.savefig(filename)
 
         if test_n == 9:
-            fig, ax = plt.subplots(3,1)
+            fig, ax = plt.subplots(3, 1)
 
             LTD_idx = np.array(np.where(np.diff(result_weights) < 0.0))
             LTD_values = np.diff(result_weights)[LTD_idx]
             print(type(LTD_idx))
             print(LTD_values)
 
-            ax[0].plot(data["events"]["times"][indices], result_weights, '*--')
+            ax[0].plot(data["events"]["times"][indices], result_weights, "*--")
             ax[0].set_ylabel("Synaptic weight")
-            #ax[1].plot(data["events"]["times"][indices][:-1], np.diff(result_weights))
-            
-            ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[1].scatter(simple_MLI_times, target_id*np.ones(len(simple_MLI_times)), label='MLI')
-            ax[1].scatter(complex_MLI_times, target_id*np.ones(len(complex_MLI_times)), color="red", label='Complex spikes')
-            ax[1].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
-            #ax[1].scatter(complex_MLI_times, source_id*np.ones(len(complex_MLI_times)), color = "white")
-            ax[2].legend(fontsize='small')
+            # ax[1].plot(data["events"]["times"][indices][:-1], np.diff(result_weights))
+
+            ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+            ax[1].scatter(
+                simple_MLI_times,
+                target_id * np.ones(len(simple_MLI_times)),
+                label="MLI",
+            )
+            ax[1].scatter(
+                complex_MLI_times,
+                target_id * np.ones(len(complex_MLI_times)),
+                color="red",
+                label="Complex spikes",
+            )
+            ax[1].scatter(
+                simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+            )
+            # ax[1].scatter(complex_MLI_times, source_id*np.ones(len(complex_MLI_times)), color = "white")
+            ax[2].legend(fontsize="small")
             ax[1].set_ylim(0, 5)
             ax[1].set_xlabel("Time [ms]")
             ax[1].set_ylabel("Neuron gID")
             ax[2].plot(LTD_idx.flatten(), -LTD_values.flatten())
-            ax[2].set_ylabel('LTD amount')
+            ax[2].set_ylabel("LTD amount")
 
-            subplot_labels = ['A', 'B', 'C']
+            subplot_labels = ["A", "B", "C"]
             for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
+                axs.text(
+                    -0.1,
+                    1.1,
+                    subplot_labels[i],
+                    transform=axs.transAxes,
+                    fontsize=16,
+                    fontweight="bold",
+                    va="top",
+                    ha="right",
+                )
+                ax[i].spines["top"].set_visible(False)
+                ax[i].spines["right"].set_visible(False)
+                ax[i].spines["bottom"].set_visible(True)
+                ax[i].spines["left"].set_visible(True)
 
             filename = f"{directory}/LTP_LTD.png"
             os.makedirs(directory, exist_ok=True)
             plt.tight_layout()
             plt.savefig(filename)
 
-def plot_LTD(pf_mli_conns, data, weight_matrix, IO, MLI, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, test_n):
-    senders = data['events']['senders']
-    targets = data['events']['targets']
-    weights = data['events']['weights']
-    #print(data['events'])
+
+def plot_LTD(
+    pf_mli_conns,
+    data,
+    weight_matrix,
+    IO,
+    MLI,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_MLI_tms,
+    MLI_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    weights = data["events"]["weights"]
+    # print(data['events'])
     for conn in pf_mli_conns:
 
-        #print(conn)
+        # print(conn)
         N = len(MLI)
         source_id = conn.get("source")
         target_id = conn.get("target")
-        #print("source_id: ", source_id)
-        #print("starget_id: ", target_id)
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
 
         indices = np.where((senders == source_id) & (targets == target_id))
         result_weights = weights[indices]
 
         # Find IO corresponding to MLI
-        connection = nest.GetConnections(source = IO, target = MLI[target_id - N-1])
+        connection = nest.GetConnections(source=IO, target=MLI[target_id - N - 1])
         IO_sender = connection.get("source")
-        #print("Corresponding IO: ", IO_sender)
-        
+        # print("Corresponding IO: ", IO_sender)
+
         # Get the spikes of IO, Gr and MLI
         IO_times_tot = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-        #print("IO spikes: ", IO_times)
-        
-        total_MLI_times = [t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id]
-        complex_MLI_times_tot = [t for t in total_MLI_times if t-1.0 in IO_times_tot]
-        print('complex times: ', complex_MLI_times_tot)
-        simple_MLI_times_tot = [t for t in total_MLI_times if t not in complex_MLI_times_tot]
-        #print("MLI simple spikes: ", simple_MLI_times)
-        #print("MLI complex spikes: ", complex_MLI_times)
+        # print("IO spikes: ", IO_times)
+
+        total_MLI_times = [
+            t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id
+        ]
+        complex_MLI_times_tot = [t for t in total_MLI_times if t - 1.0 in IO_times_tot]
+        print("complex times: ", complex_MLI_times_tot)
+        simple_MLI_times_tot = [
+            t for t in total_MLI_times if t not in complex_MLI_times_tot
+        ]
+        # print("MLI simple spikes: ", simple_MLI_times)
+        # print("MLI complex spikes: ", complex_MLI_times)
 
         first_complex_spike = complex_MLI_times_tot[0]
-        first_complex_step = int(first_complex_spike/0.1)
+        first_complex_step = int(first_complex_spike / 0.1)
 
-        total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
         complex_Gr_times = [t for t in total_Gr_times if t in complex_MLI_times_tot]
         simple_Gr_times_tot = [t for t in total_Gr_times if t not in complex_Gr_times]
-        #print("Simple Gr spikes: ", simple_Gr_times)
-        #print("Complex Gr spikes: ", complex_Gr_times)
-        #assert(simple_Gr_times)
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
         # Plot weight and spikes
 
         LTD_idx = np.array(np.where(np.diff(result_weights) < 0.0))
         LTD_values = np.diff(result_weights)[LTD_idx]
-        #print(type(LTD_idx))
-        #print(LTD_values)
+        # print(type(LTD_idx))
+        # print(LTD_values)
 
         for num_window, cs in enumerate(complex_MLI_times_tot):
-            print('num window: ', num_window)
+            print("num window: ", num_window)
             end = cs + 50
             start = cs - 202.0
 
             time_window = np.arange(start, end, 0.1)
             print("time_window: ", time_window)
-            
-            weight_indices = np.where((data["events"]["times"] >= time_window[0]) & (data["events"]["times"] <= time_window[-1]))
-            #print(data["events"]["times"])
-            weight_times = data["events"]["times"][weight_indices]
-            print('weight_times: ', weight_times)
-            print('weights: ', result_weights[weight_indices])
 
-            #print('IO_times prima array: ', IO_times)
+            weight_indices = np.where(
+                (data["events"]["times"] >= time_window[0])
+                & (data["events"]["times"] <= time_window[-1])
+            )
+            # print(data["events"]["times"])
+            weight_times = data["events"]["times"][weight_indices]
+            print("weight_times: ", weight_times)
+            print("weights: ", result_weights[weight_indices])
+
+            # print('IO_times prima array: ', IO_times)
             IO_times = np.array(IO_times_tot)
-            #print('IO_times dopo array: ', IO_times)
-            IO_indices = np.where((IO_times >= time_window[0]) & (IO_times <= time_window[-1]))
+            # print('IO_times dopo array: ', IO_times)
+            IO_indices = np.where(
+                (IO_times >= time_window[0]) & (IO_times <= time_window[-1])
+            )
             IO_times = IO_times[IO_indices]
-            print('IO_times: ', IO_times)
+            print("IO_times: ", IO_times)
 
             simple_MLI_times = np.array(simple_MLI_times_tot)
-            simple_MLI_indices = np.where((simple_MLI_times >= time_window[0]) & (simple_MLI_times <= time_window[-1]))
+            simple_MLI_indices = np.where(
+                (simple_MLI_times >= time_window[0])
+                & (simple_MLI_times <= time_window[-1])
+            )
             simple_MLI_times = simple_MLI_times[simple_MLI_indices]
-            print('simple MLI times: ', simple_MLI_times)
+            print("simple MLI times: ", simple_MLI_times)
 
             complex_MLI_times = np.array(complex_MLI_times_tot)
-            complex_MLI_indices = np.where((complex_MLI_times >= time_window[0]) & (complex_MLI_times <= time_window[-1]))
+            complex_MLI_indices = np.where(
+                (complex_MLI_times >= time_window[0])
+                & (complex_MLI_times <= time_window[-1])
+            )
             complex_MLI_times = complex_MLI_times[complex_MLI_indices]
-            print('complex MLI times: ', complex_MLI_times)
+            print("complex MLI times: ", complex_MLI_times)
 
             simple_Gr_times = np.array(simple_Gr_times_tot)
-            simple_Gr_indices = np.where((simple_Gr_times >= time_window[0]) & (simple_Gr_times <= time_window[-1]))
+            simple_Gr_indices = np.where(
+                (simple_Gr_times >= time_window[0])
+                & (simple_Gr_times <= time_window[-1])
+            )
             simple_Gr_times = simple_Gr_times[simple_Gr_indices]
-            print('Gr times: ', simple_Gr_times)
+            print("Gr times: ", simple_Gr_times)
 
             result_weights = weight_matrix[int(math.floor(start)) : int(math.ceil(end))]
-            interpolator = interp1d(np.arange(len(result_weights))+start, result_weights, kind='linear')  # Linear interpolation
+            interpolator = interp1d(
+                np.arange(len(result_weights)) + start, result_weights, kind="linear"
+            )  # Linear interpolation
 
             # Compute interpolated values
-            values_high_res = interpolator(np.arange(len(result_weights))+start)
-            
-            fig, ax = plt.subplots(3,1, figsize = (8, 8), sharex=True)
-            #ax[0].plot(weight_times, result_weights[weight_indices], linewidth = 4)
-            ax[0].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[0].scatter(simple_MLI_times, target_id*np.ones(len(simple_MLI_times)), label='MLI')
-            ax[0].scatter(complex_MLI_times, target_id*np.ones(len(complex_MLI_times)), color="red", label='Complex spikes')
-            ax[0].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
+            values_high_res = interpolator(np.arange(len(result_weights)) + start)
+
+            fig, ax = plt.subplots(3, 1, figsize=(8, 8), sharex=True)
+            # ax[0].plot(weight_times, result_weights[weight_indices], linewidth = 4)
+            ax[0].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+            ax[0].scatter(
+                simple_MLI_times,
+                target_id * np.ones(len(simple_MLI_times)),
+                label="MLI",
+            )
+            ax[0].scatter(
+                complex_MLI_times,
+                target_id * np.ones(len(complex_MLI_times)),
+                color="red",
+                label="Complex spikes",
+            )
+            ax[0].scatter(
+                simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+            )
             ax[0].set_ylim(0, 8)
-            #ax[1].set_xlim(start, end)
+            # ax[1].set_xlim(start, end)
             ax[0].set_xlabel("Time [ms]")
             ax[0].set_ylabel("Neuron gID")
-            ax[0].legend(fontsize = 'small')
+            ax[0].legend(fontsize="small")
             ax[0].tick_params(labelbottom=True)
-            #ax[0].axhline(result_weights[weight_indices][0], xmin=0, xmax=1, color = 'k', linestyle='--')
-            #ax[0].axhline(result_weights[weight_indices][-1], xmin=0, xmax=1, color = 'k', linestyle='--')
-            #ax[1].plot(data["events"]["times"][indices][:-1], np.diff(result_weights))
-            
-            ax[1].plot(np.arange(len(result_weights))+start, values_high_res)
+            # ax[0].axhline(result_weights[weight_indices][0], xmin=0, xmax=1, color = 'k', linestyle='--')
+            # ax[0].axhline(result_weights[weight_indices][-1], xmin=0, xmax=1, color = 'k', linestyle='--')
+            # ax[1].plot(data["events"]["times"][indices][:-1], np.diff(result_weights))
+
+            ax[1].plot(np.arange(len(result_weights)) + start, values_high_res)
             ax[1].set_ylabel("Synaptic weight")
             ax[1].set_xlabel("Time [ms]")
-            ax[1].set_ylim((0.14,0.4))
+            ax[1].set_ylim((0.14, 0.4))
             ax[1].tick_params(labelbottom=True)
 
-            ax[2].plot(np.arange(len(result_weights))[:-1]+start, np.diff(values_high_res), 'k--')
+            ax[2].plot(
+                np.arange(len(result_weights))[:-1] + start,
+                np.diff(values_high_res),
+                "k--",
+            )
             ax[2].set_ylabel("Diff weight")
-            ax[2].set_ylim((-1.7,1.2))
+            ax[2].set_ylim((-1.7, 1.2))
             ax[2].set_xlabel("Time [ms]")
             ax[2].tick_params(labelbottom=True)
 
-            subplot_labels = ['A', 'B', 'C']
+            subplot_labels = ["A", "B", "C"]
             for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
+                axs.text(
+                    -0.1,
+                    1.1,
+                    subplot_labels[i],
+                    transform=axs.transAxes,
+                    fontsize=16,
+                    fontweight="bold",
+                    va="top",
+                    ha="right",
+                )
+                ax[i].spines["top"].set_visible(False)
+                ax[i].spines["right"].set_visible(False)
+                ax[i].spines["bottom"].set_visible(True)
+                ax[i].spines["left"].set_visible(True)
 
             directory = f"figures_plasticity_alpha/test_{test_n}"
             filename = f"{directory}/window_{num_window}.png"
             os.makedirs(directory, exist_ok=True)
             plt.tight_layout()
             plt.savefig(filename)
-        
-            
+
 
 def reformat_weights(weights):
     total_steps = len(weights)
@@ -420,247 +590,384 @@ def reformat_weights(weights):
     weight_matrix = np.zeros((n_conns, total_steps))
     for timestep in range(total_steps):
         for conn in range(n_conns):
-            weight_matrix[conn, timestep] =round(weights[timestep][conn], 3)
-    
+            weight_matrix[conn, timestep] = round(weights[timestep][conn], 3)
+
     return weight_matrix
 
-def plot_synaptic_matrix(pf_mli_conns, data, weight_matrix, IO, MLI, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, test_n):
-    senders = data['events']['senders']
-    targets = data['events']['targets']
-    #weights = data['events']['weights']
-    #print(data['events'])
+
+def plot_synaptic_matrix(
+    pf_mli_conns,
+    data,
+    weight_matrix,
+    IO,
+    MLI,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_MLI_tms,
+    MLI_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    # weights = data['events']['weights']
+    # print(data['events'])
     for idx, conn in enumerate(pf_mli_conns):
-        #print(conn)
+        # print(conn)
         N = len(MLI)
         source_id = conn.get("source")
         target_id = conn.get("target")
-        #print("source_id: ", source_id)
-        #print("starget_id: ", target_id)
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
 
         indices = np.where((senders == source_id) & (targets == target_id))
-        #print(type(weight_matrix))
-        #print(np.shape(weight_matrix))
+        # print(type(weight_matrix))
+        # print(np.shape(weight_matrix))
         result_weights = weight_matrix[idx, :]
 
         # Find IO corresponding to MLI
-        connection = nest.GetConnections(source = IO, target = MLI[target_id - N-1])
+        connection = nest.GetConnections(source=IO, target=MLI[target_id - N - 1])
         IO_sender = connection.get("source")
-        #print("Corresponding IO: ", IO_sender)
-        
+        # print("Corresponding IO: ", IO_sender)
+
         # Get the spikes of IO, Gr and MLI
         IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-        #print("IO spikes: ", IO_times)
-        
-        total_MLI_times = [t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id]
-        complex_MLI_times = [t for t in total_MLI_times if t-1.0 in IO_times]
-        simple_MLI_times = [t for t in total_MLI_times if t not in complex_MLI_times]
-        #print("MLI simple spikes: ", simple_MLI_times)
-        #print("MLI complex spikes: ", complex_MLI_times)
+        # print("IO spikes: ", IO_times)
 
-        total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
+        total_MLI_times = [
+            t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id
+        ]
+        complex_MLI_times = [t for t in total_MLI_times if t - 1.0 in IO_times]
+        simple_MLI_times = [t for t in total_MLI_times if t not in complex_MLI_times]
+        # print("MLI simple spikes: ", simple_MLI_times)
+        # print("MLI complex spikes: ", complex_MLI_times)
+
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
         complex_Gr_times = [t for t in total_Gr_times if t in complex_MLI_times]
         simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
-        #print("Simple Gr spikes: ", simple_Gr_times)
-        #print("Complex Gr spikes: ", complex_Gr_times)
-        #assert(simple_Gr_times)
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
         # Plot weight and spikes
         directory = f"figures_plasticity_alpha/test_{test_n}"
         if test_n != 9:
-            fig, ax = plt.subplots(2,1)
-            ax[0].plot(np.arange(1000), result_weights, '--')
+            fig, ax = plt.subplots(2, 1)
+            ax[0].plot(np.arange(1000), result_weights, "--")
             ax[0].set_ylabel("Synaptic weight")
-            ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[1].scatter(simple_MLI_times, target_id*np.ones(len(simple_MLI_times)), label='MLI')
-            ax[1].scatter(complex_MLI_times, target_id*np.ones(len(complex_MLI_times)), color="red", label='Complex spikes')
-            ax[1].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
-            ax[1].scatter(complex_MLI_times, source_id*np.ones(len(complex_MLI_times)), color = "white", s = 70)
-            ax[1].legend(fontsize='small')
+            ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+            ax[1].scatter(
+                simple_MLI_times,
+                target_id * np.ones(len(simple_MLI_times)),
+                label="MLI",
+            )
+            ax[1].scatter(
+                complex_MLI_times,
+                target_id * np.ones(len(complex_MLI_times)),
+                color="red",
+                label="Complex spikes",
+            )
+            ax[1].scatter(
+                simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+            )
+            ax[1].scatter(
+                complex_MLI_times,
+                source_id * np.ones(len(complex_MLI_times)),
+                color="white",
+                s=70,
+            )
+            ax[1].legend(fontsize="small")
             ax[1].set_ylim(0, 20)
             ax[1].set_xlabel("Time [ms]")
             ax[1].set_ylabel("Neuron gID")
 
-            subplot_labels = ['A', 'B']
+            subplot_labels = ["A", "B"]
             for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
-                
+                axs.text(
+                    -0.1,
+                    1.1,
+                    subplot_labels[i],
+                    transform=axs.transAxes,
+                    fontsize=16,
+                    fontweight="bold",
+                    va="top",
+                    ha="right",
+                )
+                ax[i].spines["top"].set_visible(False)
+                ax[i].spines["right"].set_visible(False)
+                ax[i].spines["bottom"].set_visible(True)
+                ax[i].spines["left"].set_visible(True)
+
             filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
             os.makedirs(directory, exist_ok=True)
 
         else:
-            fig, ax = plt.subplots(3,1)
+            fig, ax = plt.subplots(3, 1)
 
-            ax[0].plot(np.arange(4300), result_weights, '--')
+            ax[0].plot(np.arange(4300), result_weights, "--")
             ax[0].set_ylabel("Synaptic weight")
             ax[1].plot(np.arange(4299), np.diff(result_weights))
-            ax[1].set_ylabel('Weight change')
-            ax[2].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[2].scatter(simple_MLI_times, target_id*np.ones(len(simple_MLI_times)), label='Simple MLI')
-            ax[2].scatter(complex_MLI_times, target_id*np.ones(len(complex_MLI_times)), color="red", label='Complex spikes')
-            ax[2].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
-            #ax[2].scatter(complex_MLI_times, source_id*np.ones(len(complex_MLI_times)), color = "white")
-            ax[2].legend(fontsize='small')
+            ax[1].set_ylabel("Weight change")
+            ax[2].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+            ax[2].scatter(
+                simple_MLI_times,
+                target_id * np.ones(len(simple_MLI_times)),
+                label="Simple MLI",
+            )
+            ax[2].scatter(
+                complex_MLI_times,
+                target_id * np.ones(len(complex_MLI_times)),
+                color="red",
+                label="Complex spikes",
+            )
+            ax[2].scatter(
+                simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+            )
+            # ax[2].scatter(complex_MLI_times, source_id*np.ones(len(complex_MLI_times)), color = "white")
+            ax[2].legend(fontsize="small")
             ax[2].set_ylim(0, 20)
             ax[2].set_xlabel("Time [ms]")
             ax[2].set_ylabel("Neuron gID")
 
-            subplot_labels = ['A', 'B', 'C']
+            subplot_labels = ["A", "B", "C"]
             for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
+                axs.text(
+                    -0.1,
+                    1.1,
+                    subplot_labels[i],
+                    transform=axs.transAxes,
+                    fontsize=16,
+                    fontweight="bold",
+                    va="top",
+                    ha="right",
+                )
+                ax[i].spines["top"].set_visible(False)
+                ax[i].spines["right"].set_visible(False)
+                ax[i].spines["bottom"].set_visible(True)
+                ax[i].spines["left"].set_visible(True)
 
             filename = f"{directory}/LTP_LTD.png"
             os.makedirs(directory, exist_ok=True)
         plt.tight_layout()
         plt.savefig(filename)
-    
-def plot_simple_spike(pf_mli_conns, data, weight_matrix, IO, MLI, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, test_n):
-        senders = data['events']['senders']
-        targets = data['events']['targets']
-        #weights = data['events']['weights']
-        #print(data['events'])
-        for idx, conn in enumerate(pf_mli_conns):
-            #print(conn)
-            N = len(MLI)
-            source_id = conn.get("source")
-            target_id = conn.get("target")
-            #print("source_id: ", source_id)
-            #print("starget_id: ", target_id)
 
-            indices = np.where((senders == source_id) & (targets == target_id))
-            #print(type(weight_matrix))
-            #print(np.shape(weight_matrix))
-            result_weights = weight_matrix[idx, :]
 
-            # Find IO corresponding to MLI
-            connection = nest.GetConnections(source = IO, target = MLI[target_id - N-1])
-            IO_sender = connection.get("source")
-            #print("Corresponding IO: ", IO_sender)
-            
-            # Get the spikes of IO, Gr and MLI
-            IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-            #print("IO spikes: ", IO_times)
-            
-            total_MLI_times = [t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id]
-            complex_MLI_times = [t for t in total_MLI_times if t-1.0 in IO_times]
-            simple_MLI_times = [t for t in total_MLI_times if t not in complex_MLI_times]
-            #print("MLI simple spikes: ", simple_MLI_times)
-            #print("MLI complex spikes: ", complex_MLI_times)
+def plot_simple_spike(
+    pf_mli_conns,
+    data,
+    weight_matrix,
+    IO,
+    MLI,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_MLI_tms,
+    MLI_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    # weights = data['events']['weights']
+    # print(data['events'])
+    for idx, conn in enumerate(pf_mli_conns):
+        # print(conn)
+        N = len(MLI)
+        source_id = conn.get("source")
+        target_id = conn.get("target")
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
 
-            total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
-            complex_Gr_times = [t for t in total_Gr_times if t in complex_MLI_times]
-            simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
-            #print("Simple Gr spikes: ", simple_Gr_times)
-            #print("Complex Gr spikes: ", complex_Gr_times)
-            #assert(simple_Gr_times)
-            # Plot weight and spikes
-            fig, ax = plt.subplots(2,1)
-            ax[0].plot(np.arange(1000), result_weights, '--')
-            ax[0].set_ylabel("Synaptic weight")
-            ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[1].scatter(simple_MLI_times, target_id*np.ones(len(simple_MLI_times)), label='MLI')
-            ax[1].scatter(complex_MLI_times, target_id*np.ones(len(complex_MLI_times)), color="red", label='Complex MLI')
-            ax[1].scatter(simple_Gr_times[-1], source_id*np.ones(len(simple_Gr_times))[-1], label='Simple GR')
-            ax[1].legend(fontsize='small')
-            ax[1].set_ylim(0, 12)
-            ax[1].set_xlabel("Time [ms]")
-            ax[1].set_ylabel("Neuron gID")
+        indices = np.where((senders == source_id) & (targets == target_id))
+        # print(type(weight_matrix))
+        # print(np.shape(weight_matrix))
+        result_weights = weight_matrix[idx, :]
 
-            subplot_labels = ['A', 'B']
-            for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
+        # Find IO corresponding to MLI
+        connection = nest.GetConnections(source=IO, target=MLI[target_id - N - 1])
+        IO_sender = connection.get("source")
+        # print("Corresponding IO: ", IO_sender)
 
-            directory = f"figures_plasticity_alpha/test_{test_n}"
-            filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
-            os.makedirs(directory, exist_ok=True)
-            plt.tight_layout()
-            plt.savefig(filename)
+        # Get the spikes of IO, Gr and MLI
+        IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
+        # print("IO spikes: ", IO_times)
 
-def plot_complex_spike(pf_mli_conns, data, weight_matrix, IO, MLI, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_MLI_tms, MLI_evs, test_n):
-        senders = data['events']['senders']
-        targets = data['events']['targets']
-        #weights = data['events']['weights']
-        #print(data['events'])
-        for idx, conn in enumerate(pf_mli_conns):
-            #print(conn)
-            N = len(MLI)
-            source_id = conn.get("source")
-            target_id = conn.get("target")
-            #print("source_id: ", source_id)
-            #print("starget_id: ", target_id)
+        total_MLI_times = [
+            t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id
+        ]
+        complex_MLI_times = [t for t in total_MLI_times if t - 1.0 in IO_times]
+        simple_MLI_times = [t for t in total_MLI_times if t not in complex_MLI_times]
+        # print("MLI simple spikes: ", simple_MLI_times)
+        # print("MLI complex spikes: ", complex_MLI_times)
 
-            indices = np.where((senders == source_id) & (targets == target_id))
-            #print(type(weight_matrix))
-            #print(np.shape(weight_matrix))
-            result_weights = weight_matrix[idx, :]
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
+        complex_Gr_times = [t for t in total_Gr_times if t in complex_MLI_times]
+        simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
+        # Plot weight and spikes
+        fig, ax = plt.subplots(2, 1)
+        ax[0].plot(np.arange(1000), result_weights, "--")
+        ax[0].set_ylabel("Synaptic weight")
+        ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+        ax[1].scatter(
+            simple_MLI_times, target_id * np.ones(len(simple_MLI_times)), label="MLI"
+        )
+        ax[1].scatter(
+            complex_MLI_times,
+            target_id * np.ones(len(complex_MLI_times)),
+            color="red",
+            label="Complex MLI",
+        )
+        ax[1].scatter(
+            simple_Gr_times[-1],
+            source_id * np.ones(len(simple_Gr_times))[-1],
+            label="Simple GR",
+        )
+        ax[1].legend(fontsize="small")
+        ax[1].set_ylim(0, 12)
+        ax[1].set_xlabel("Time [ms]")
+        ax[1].set_ylabel("Neuron gID")
 
-            # Find IO corresponding to MLI
-            connection = nest.GetConnections(source = IO, target = MLI[target_id - N-1])
-            IO_sender = connection.get("source")
-            #print("Corresponding IO: ", IO_sender)
-            
-            # Get the spikes of IO, Gr and MLI
-            IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-            #print("IO spikes: ", IO_times)
-            
-            total_MLI_times = [t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id]
-            complex_MLI_times = [t for t in total_MLI_times if t-1.0 in IO_times]
-            simple_MLI_times = [t for t in total_MLI_times if t not in complex_MLI_times]
-            #print("MLI simple spikes: ", simple_MLI_times)
-            #print("MLI complex spikes: ", complex_MLI_times)
+        subplot_labels = ["A", "B"]
+        for i, axs in enumerate(ax):
+            axs.text(
+                -0.1,
+                1.1,
+                subplot_labels[i],
+                transform=axs.transAxes,
+                fontsize=16,
+                fontweight="bold",
+                va="top",
+                ha="right",
+            )
+            ax[i].spines["top"].set_visible(False)
+            ax[i].spines["right"].set_visible(False)
+            ax[i].spines["bottom"].set_visible(True)
+            ax[i].spines["left"].set_visible(True)
 
-            total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
-            complex_Gr_times = [t for t in total_Gr_times if t in complex_MLI_times]
-            simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
-            #print("Simple Gr spikes: ", simple_Gr_times)
-            #print("Complex Gr spikes: ", complex_Gr_times)
-            #assert(simple_Gr_times)
-            # Plot weight and spikes
-            fig, ax = plt.subplots(2,1)
-            ax[0].plot(np.arange(1000), result_weights, '--')
-            ax[0].set_ylabel("Synaptic weight")
-            ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[1].scatter(simple_MLI_times, target_id*np.ones(len(simple_MLI_times)), label='Simple MLI')
-            ax[1].scatter(complex_MLI_times, target_id*np.ones(len(complex_MLI_times)), color="red", label='Complex spikes')
-            #ax[1].scatter(total_Gr_times[-1], source_id*np.ones(len(total_Gr_times))[-1], color = "red")
-            ax[1].legend(fontsize='small')
-            ax[1].set_ylim(0, 12)
-            ax[1].set_xlabel("Time [ms]")
-            ax[1].set_ylabel("Neuron gID")
+        directory = f"figures_plasticity_alpha/test_{test_n}"
+        filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
+        os.makedirs(directory, exist_ok=True)
+        plt.tight_layout()
+        plt.savefig(filename)
 
-            subplot_labels = ['A', 'B']
-            for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
 
-            directory = f"figures_plasticity_alpha/test_{test_n}"
-            filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
-            os.makedirs(directory, exist_ok=True)
-            plt.tight_layout()
-            plt.savefig(filename)
+def plot_complex_spike(
+    pf_mli_conns,
+    data,
+    weight_matrix,
+    IO,
+    MLI,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_MLI_tms,
+    MLI_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    # weights = data['events']['weights']
+    # print(data['events'])
+    for idx, conn in enumerate(pf_mli_conns):
+        # print(conn)
+        N = len(MLI)
+        source_id = conn.get("source")
+        target_id = conn.get("target")
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
+
+        indices = np.where((senders == source_id) & (targets == target_id))
+        # print(type(weight_matrix))
+        # print(np.shape(weight_matrix))
+        result_weights = weight_matrix[idx, :]
+
+        # Find IO corresponding to MLI
+        connection = nest.GetConnections(source=IO, target=MLI[target_id - N - 1])
+        IO_sender = connection.get("source")
+        # print("Corresponding IO: ", IO_sender)
+
+        # Get the spikes of IO, Gr and MLI
+        IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
+        # print("IO spikes: ", IO_times)
+
+        total_MLI_times = [
+            t for t, e in zip(corrected_MLI_tms, MLI_evs) if e == target_id
+        ]
+        complex_MLI_times = [t for t in total_MLI_times if t - 1.0 in IO_times]
+        simple_MLI_times = [t for t in total_MLI_times if t not in complex_MLI_times]
+        # print("MLI simple spikes: ", simple_MLI_times)
+        # print("MLI complex spikes: ", complex_MLI_times)
+
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
+        complex_Gr_times = [t for t in total_Gr_times if t in complex_MLI_times]
+        simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
+        # Plot weight and spikes
+        fig, ax = plt.subplots(2, 1)
+        ax[0].plot(np.arange(1000), result_weights, "--")
+        ax[0].set_ylabel("Synaptic weight")
+        ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+        ax[1].scatter(
+            simple_MLI_times,
+            target_id * np.ones(len(simple_MLI_times)),
+            label="Simple MLI",
+        )
+        ax[1].scatter(
+            complex_MLI_times,
+            target_id * np.ones(len(complex_MLI_times)),
+            color="red",
+            label="Complex spikes",
+        )
+        # ax[1].scatter(total_Gr_times[-1], source_id*np.ones(len(total_Gr_times))[-1], color = "red")
+        ax[1].legend(fontsize="small")
+        ax[1].set_ylim(0, 12)
+        ax[1].set_xlabel("Time [ms]")
+        ax[1].set_ylabel("Neuron gID")
+
+        subplot_labels = ["A", "B"]
+        for i, axs in enumerate(ax):
+            axs.text(
+                -0.1,
+                1.1,
+                subplot_labels[i],
+                transform=axs.transAxes,
+                fontsize=16,
+                fontweight="bold",
+                va="top",
+                ha="right",
+            )
+            ax[i].spines["top"].set_visible(False)
+            ax[i].spines["right"].set_visible(False)
+            ax[i].spines["bottom"].set_visible(True)
+            ax[i].spines["left"].set_visible(True)
+
+        directory = f"figures_plasticity_alpha/test_{test_n}"
+        filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
+        os.makedirs(directory, exist_ok=True)
+        plt.tight_layout()
+        plt.savefig(filename)
+
 
 def correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder):
     cf_spikes = nest.GetStatus(cf_recorder)[0]["events"]
     cf_tms = cf_spikes["times"]
     cf_evs = cf_spikes["senders"]
-    #print('evs inside function: ', cf_evs)
+    # print('evs inside function: ', cf_evs)
 
     MLI_spikes = nest.GetStatus(MLI_recorder)[0]["events"]
     MLI_tms = MLI_spikes["times"]
@@ -677,25 +984,40 @@ def correct_spike_times(cf_recorder, MLI_recorder, Gr_recorder):
         corrected_cf_tms.append(corrected_time)
 
     corrected_cf_tms = [round(t, 1) for t in corrected_cf_tms]
-    #print('cf spikes: (', corrected_cf_tms, '), (', cf_evs, ')')
+    # print('cf spikes: (', corrected_cf_tms, '), (', cf_evs, ')')
 
     # MLI
     corrected_MLI_tms = []
     for idx, (time, sender) in enumerate(zip(MLI_tms, MLI_evs)):
-        corrected_time = time + (sender - min(MLI_evs) +1)
+        corrected_time = time + (sender - min(MLI_evs) + 1)
         corrected_MLI_tms.append(corrected_time)
 
     corrected_MLI_tms = [round(t, 1) for t in corrected_MLI_tms]
-    #print('MLI spikes: (', corrected_MLI_tms, '), (', MLI_evs, ')\n')
-    
-    MLI_complex_tms = [spike for spike in corrected_MLI_tms if (spike - 1.0) in corrected_cf_tms]
-    MLI_complex_evs = [ev for (spike, ev) in zip(corrected_MLI_tms, MLI_evs) if spike in MLI_complex_tms]
-    #print('Complex MLI spikes: (', MLI_complex_tms, '), (', MLI_complex_evs, ')\n')
+    # print('MLI spikes: (', corrected_MLI_tms, '), (', MLI_evs, ')\n')
+
+    MLI_complex_tms = [
+        spike for spike in corrected_MLI_tms if (spike - 1.0) in corrected_cf_tms
+    ]
+    MLI_complex_evs = [
+        ev
+        for (spike, ev) in zip(corrected_MLI_tms, MLI_evs)
+        if spike in MLI_complex_tms
+    ]
+    # print('Complex MLI spikes: (', MLI_complex_tms, '), (', MLI_complex_evs, ')\n')
 
     # Granule cells
     corrected_gr_spikes = [round(t + s, 1) for t, s in zip(Gr_tms, Gr_evs)]
-    assert(len(corrected_gr_spikes) == len(Gr_tms))
+    assert len(corrected_gr_spikes) == len(Gr_tms)
 
-    #print('Gr spikes: (', corrected_gr_spikes, '), (', Gr_evs, ')\n')
+    # print('Gr spikes: (', corrected_gr_spikes, '), (', Gr_evs, ')\n')
 
-    return corrected_cf_tms, cf_evs, corrected_MLI_tms, MLI_evs, MLI_complex_tms, MLI_complex_evs, corrected_gr_spikes, Gr_evs
+    return (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_MLI_tms,
+        MLI_evs,
+        MLI_complex_tms,
+        MLI_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    )

--- a/tests/tests_plasticity/validation_synapse_sinexp.py
+++ b/tests/tests_plasticity/validation_synapse_sinexp.py
@@ -5,172 +5,244 @@ import os
 import math
 from scipy.interpolate import interp1d
 
-def plot_synaptic_weight(pf_pc_conns, data, IO, PC, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, test_n):
-    senders = data['events']['senders']
-    targets = data['events']['targets']
-    weights = data['events']['weights']
-    
-    
+
+def plot_synaptic_weight(
+    pf_pc_conns,
+    data,
+    IO,
+    PC,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_PC_tms,
+    PC_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    weights = data["events"]["weights"]
+
     for conn in pf_pc_conns:
-        #print(conn)
+        # print(conn)
         N = len(PC)
         source_id = conn.get("source")
         target_id = conn.get("target")
-        #print("source_id: ", source_id)
-        #print("starget_id: ", target_id)
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
 
         indices = np.where((senders == source_id) & (targets == target_id))
         result_weights = weights[indices]
 
         # Find IO corresponding to PC
-        connection = nest.GetConnections(source = IO, target = PC[target_id - N-1])
+        connection = nest.GetConnections(source=IO, target=PC[target_id - N - 1])
         IO_sender = connection.get("source")
-        #print("Corresponding IO: ", IO_sender)
-        
+        # print("Corresponding IO: ", IO_sender)
+
         # Get the spikes of IO, Gr and PC
         IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-        #print("IO spikes: ", IO_times)
-        
+        # print("IO spikes: ", IO_times)
+
         total_PC_times = [t for t, e in zip(corrected_PC_tms, PC_evs) if e == target_id]
-        complex_PC_times = [t for t in total_PC_times if t-1.0 in IO_times]
+        complex_PC_times = [t for t in total_PC_times if t - 1.0 in IO_times]
         simple_PC_times = [t for t in total_PC_times if t not in complex_PC_times]
-        #print("Pc simple spikes: ", simple_PC_times)
-        #print("Pc complex spikes: ", complex_PC_times)
+        # print("Pc simple spikes: ", simple_PC_times)
+        # print("Pc complex spikes: ", complex_PC_times)
 
-        total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
-        #complex_Gr_times = [t for t in total_Gr_times if t in complex_PC_times]
-        simple_Gr_times = [t for t in total_Gr_times ]
-        #print("Simple Gr spikes: ", simple_Gr_times)
-        #print("Complex Gr spikes: ", complex_Gr_times)
-        #assert(simple_Gr_times)
- 
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
+        # complex_Gr_times = [t for t in total_Gr_times if t in complex_PC_times]
+        simple_Gr_times = [t for t in total_Gr_times]
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
 
-        fig, ax = plt.subplots(2,1)
-        ax[0].plot(data["events"]["times"][indices], result_weights, '--')
-        #print(data["events"]["times"][indices])
-        #print(result_weights)
+        fig, ax = plt.subplots(2, 1)
+        ax[0].plot(data["events"]["times"][indices], result_weights, "--")
+        # print(data["events"]["times"][indices])
+        # print(result_weights)
         ax[0].set_ylabel("Synaptic weight")
 
-        ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-        ax[1].scatter(simple_PC_times, target_id*np.ones(len(simple_PC_times)), label='Simple PC')
-        ax[1].scatter(complex_PC_times, target_id*np.ones(len(complex_PC_times)), color="red", label='Complex spikes')
-        ax[1].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
-        #ax[1].scatter(complex_PC_times, source_id*np.ones(len(complex_PC_times)), color = "white")
-        ax[1].legend(fontsize='small')
+        ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+        ax[1].scatter(
+            simple_PC_times,
+            target_id * np.ones(len(simple_PC_times)),
+            label="Simple PC",
+        )
+        ax[1].scatter(
+            complex_PC_times,
+            target_id * np.ones(len(complex_PC_times)),
+            color="red",
+            label="Complex spikes",
+        )
+        ax[1].scatter(
+            simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+        )
+        # ax[1].scatter(complex_PC_times, source_id*np.ones(len(complex_PC_times)), color = "white")
+        ax[1].legend(fontsize="small")
         ax[1].set_ylim(0, 20)
         ax[1].set_xlabel("Time [ms]")
         ax[1].set_ylabel("Neuron gID")
 
-        subplot_labels = ['A', 'B']
+        subplot_labels = ["A", "B"]
         for i, axs in enumerate(ax):
-            axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                fontsize=16, fontweight='bold', va='top', ha='right')
-            ax[i].spines['top'].set_visible(False)
-            ax[i].spines['right'].set_visible(False)
-            ax[i].spines['bottom'].set_visible(True)
-            ax[i].spines['left'].set_visible(True)
-
+            axs.text(
+                -0.1,
+                1.1,
+                subplot_labels[i],
+                transform=axs.transAxes,
+                fontsize=16,
+                fontweight="bold",
+                va="top",
+                ha="right",
+            )
+            ax[i].spines["top"].set_visible(False)
+            ax[i].spines["right"].set_visible(False)
+            ax[i].spines["bottom"].set_visible(True)
+            ax[i].spines["left"].set_visible(True)
 
         directory = f"figures_plasticity_sinexp/test_{test_n}"
         filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
         os.makedirs(directory, exist_ok=True)
         plt.tight_layout()
         plt.savefig(filename)
-        
 
         if test_n == 9:
             fig, ax = plt.subplots(3, 1, figsize=(8, 10), sharex=False)
-            
+
             # --- 1. Synaptic weight trace over time ---
-            ax[0].plot(data["events"]["times"][indices], result_weights, '*--', label='Synaptic Weight')
+            ax[0].plot(
+                data["events"]["times"][indices],
+                result_weights,
+                "*--",
+                label="Synaptic Weight",
+            )
             ax[0].set_ylabel("Synaptic weight", fontsize=12)
             ax[0].legend()
 
             # --- 2. Spike raster ---
-            ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[1].scatter(simple_PC_times, target_id*np.ones(len(simple_PC_times)), label='Simple PC')
-            ax[1].scatter(complex_PC_times, target_id*np.ones(len(complex_PC_times)), color="red", label='Complex spikes')
-            ax[1].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
+            ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+            ax[1].scatter(
+                simple_PC_times,
+                target_id * np.ones(len(simple_PC_times)),
+                label="Simple PC",
+            )
+            ax[1].scatter(
+                complex_PC_times,
+                target_id * np.ones(len(complex_PC_times)),
+                color="red",
+                label="Complex spikes",
+            )
+            ax[1].scatter(
+                simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+            )
 
             ax[1].set_ylim(0, 5)
             ax[1].set_xlabel("Time [ms]", fontsize=12)
             ax[1].set_ylabel("Neuron gID", fontsize=12)
-            ax[1].legend(fontsize='small')
+            ax[1].legend(fontsize="small")
 
             # --- 3. LTD amount vs spike time difference ---
             diffs = np.diff(result_weights)
             LTD_mask = diffs < 0  # LTD occurs when weight decreases
 
             # Define a Δt window from -200 ms to 0 ms
-            spike_time_diffs = np.linspace(-200, 0, len(diffs))  # Assuming uniform mapping
+            spike_time_diffs = np.linspace(
+                -200, 0, len(diffs)
+            )  # Assuming uniform mapping
             LTD_values = -diffs[LTD_mask]  # Make LTD amounts positive
             LTD_times = spike_time_diffs[LTD_mask]
 
-            ax[2].plot(LTD_times, LTD_values, 'o-', color='black')
-            ax[2].set_ylabel('LTD amount', fontsize=12)
-            ax[2].set_xlabel('Spike time difference [ms]', fontsize=12)
+            ax[2].plot(LTD_times, LTD_values, "o-", color="black")
+            ax[2].set_ylabel("LTD amount", fontsize=12)
+            ax[2].set_xlabel("Spike time difference [ms]", fontsize=12)
             ax[2].set_xticks(np.arange(-200, 1, 20))
             ax[2].set_xlim([-200, 0])
 
             # --- Consistent formatting for all subplots ---
-            subplot_labels = ['A', 'B', 'C']
+            subplot_labels = ["A", "B", "C"]
             for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                        fontsize=16, fontweight='bold', va='top', ha='right')
-                axs.spines['top'].set_visible(False)
-                axs.spines['right'].set_visible(False)
-                axs.spines['bottom'].set_visible(True)
-                axs.spines['left'].set_visible(True)
+                axs.text(
+                    -0.1,
+                    1.1,
+                    subplot_labels[i],
+                    transform=axs.transAxes,
+                    fontsize=16,
+                    fontweight="bold",
+                    va="top",
+                    ha="right",
+                )
+                axs.spines["top"].set_visible(False)
+                axs.spines["right"].set_visible(False)
+                axs.spines["bottom"].set_visible(True)
+                axs.spines["left"].set_visible(True)
 
             # --- Save figure ---
             filename = f"{directory}/LTP_LTD.png"
             os.makedirs(directory, exist_ok=True)
             plt.tight_layout()
             plt.savefig(filename)
-            
-            
 
-def plot_LTP(pf_pc_conns, data, weight_matrix, IO, PC, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, test_n):
-    senders = data['events']['senders']
-    targets = data['events']['targets']
-    weights = data['events']['weights']
-    #print(data['events'])
+
+def plot_LTP(
+    pf_pc_conns,
+    data,
+    weight_matrix,
+    IO,
+    PC,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_PC_tms,
+    PC_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    weights = data["events"]["weights"]
+    # print(data['events'])
     for idx, conn in enumerate(pf_pc_conns):
-        #print(conn)
+        # print(conn)
         N = len(PC)
         source_id = conn.get("source")
         target_id = conn.get("target")
-        #print("source_id: ", source_id)
-        #print("starget_id: ", target_id)
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
 
         indices = np.where((senders == source_id) & (targets == target_id))
         result_weights = weights[indices]
 
         # Find IO corresponding to PC
-        connection = nest.GetConnections(source = IO, target = PC[target_id - N-1])
+        connection = nest.GetConnections(source=IO, target=PC[target_id - N - 1])
         IO_sender = connection.get("source")
-        #print("Corresponding IO: ", IO_sender)
-        
+        # print("Corresponding IO: ", IO_sender)
+
         # Get the spikes of IO, Gr and PC
         IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-        #print("IO spikes: ", IO_times)
-        
+        # print("IO spikes: ", IO_times)
+
         total_PC_times = [t for t, e in zip(corrected_PC_tms, PC_evs) if e == target_id]
-        complex_PC_times = [t for t in total_PC_times if t-1.0 in IO_times]
+        complex_PC_times = [t for t in total_PC_times if t - 1.0 in IO_times]
         simple_PC_times = [t for t in total_PC_times if t not in complex_PC_times]
-        #print("Pc simple spikes: ", simple_PC_times)
-        #print("Pc complex spikes: ", complex_PC_times)
+        # print("Pc simple spikes: ", simple_PC_times)
+        # print("Pc complex spikes: ", complex_PC_times)
 
         first_complex_spike = complex_PC_times[0]
         print(first_complex_spike)
-        first_complex_step = int(first_complex_spike/0.1)
+        first_complex_step = int(first_complex_spike / 0.1)
         print(first_complex_step)
-        total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
         complex_Gr_times = [t for t in total_Gr_times if t in complex_PC_times]
         simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
-        #print("Simple Gr spikes: ", simple_Gr_times)
-        #print("Complex Gr spikes: ", complex_Gr_times)
-        #assert(simple_Gr_times)
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
 
         result_weights = weight_matrix[idx, :]
 
@@ -190,44 +262,66 @@ def plot_LTP(pf_pc_conns, data, weight_matrix, IO, PC, GrC, corrected_cf_tms, cf
         simple_Gr_times = simple_Gr_times[simple_Gr_indices]
 
         # Plot weight and spikes
-        fig, ax = plt.subplots(3,1, sharex = True, figsize =(8,6))
+        fig, ax = plt.subplots(3, 1, sharex=True, figsize=(8, 6))
 
         default_colors = plt.cm.tab10.colors
         green_color = default_colors[2]
-        #ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-        ax[0].scatter(simple_PC_times[:4], target_id*np.ones(len(simple_PC_times))[:4], label='Simple PC', color ="orange")
-        #ax[1].scatter(complex_PC_times, target_id*np.ones(len(complex_PC_times)), color="red", label='Complex spikes')
-        ax[0].scatter(simple_Gr_times[:4], source_id*np.ones(len(simple_Gr_times))[:4], label='GrCs', color =green_color)
-        #ax[1].scatter(complex_PC_times, source_id*np.ones(len(complex_PC_times)), color = "white")
-        ax[0].legend(fontsize='small')
+        # ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
+        ax[0].scatter(
+            simple_PC_times[:4],
+            target_id * np.ones(len(simple_PC_times))[:4],
+            label="Simple PC",
+            color="orange",
+        )
+        # ax[1].scatter(complex_PC_times, target_id*np.ones(len(complex_PC_times)), color="red", label='Complex spikes')
+        ax[0].scatter(
+            simple_Gr_times[:4],
+            source_id * np.ones(len(simple_Gr_times))[:4],
+            label="GrCs",
+            color=green_color,
+        )
+        # ax[1].scatter(complex_PC_times, source_id*np.ones(len(complex_PC_times)), color = "white")
+        ax[0].legend(fontsize="small")
         ax[0].set_ylim(0, 20)
-        #ax[0].set_xlim(0, first_complex_spike-5)
+        # ax[0].set_xlim(0, first_complex_spike-5)
         ax[0].set_xlabel("Time [ms]")
         ax[0].set_ylabel("Neuron gID")
         ax[0].tick_params(labelbottom=True)
-        
-        ax[1].plot(np.arange(math.ceil(first_complex_spike-5)), result_weights[:math.ceil(first_complex_spike-5)])
+
+        ax[1].plot(
+            np.arange(math.ceil(first_complex_spike - 5)),
+            result_weights[: math.ceil(first_complex_spike - 5)],
+        )
         ax[1].set_ylabel("Synaptic weight")
         ax[1].set_xlabel("Time [ms]")
-  
+
         ax[1].tick_params(labelbottom=True)
-        
-        ax[2].plot(np.arange(math.ceil(first_complex_spike-5))[1:], np.diff(result_weights[:math.ceil(first_complex_spike-5)]), 'k--')
+
+        ax[2].plot(
+            np.arange(math.ceil(first_complex_spike - 5))[1:],
+            np.diff(result_weights[: math.ceil(first_complex_spike - 5)]),
+            "k--",
+        )
         ax[2].set_ylabel("Diff weight")
-        ax[2].set_ylim((-1.7,1.2))
+        ax[2].set_ylim((-1.7, 1.2))
         ax[2].set_xlabel("Time [ms]")
-        
 
-            
-        subplot_labels = ['A', 'B', 'C']
+        subplot_labels = ["A", "B", "C"]
         for i, axs in enumerate(ax):
-            axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                fontsize=16, fontweight='bold', va='top', ha='right')
-            ax[i].spines['top'].set_visible(False)
-            ax[i].spines['right'].set_visible(False)
-            ax[i].spines['bottom'].set_visible(True)
-            ax[i].spines['left'].set_visible(True)
-
+            axs.text(
+                -0.1,
+                1.1,
+                subplot_labels[i],
+                transform=axs.transAxes,
+                fontsize=16,
+                fontweight="bold",
+                va="top",
+                ha="right",
+            )
+            ax[i].spines["top"].set_visible(False)
+            ax[i].spines["right"].set_visible(False)
+            ax[i].spines["bottom"].set_visible(True)
+            ax[i].spines["left"].set_visible(True)
 
         directory = f"figures_plasticity_sinexp/test_{test_n}"
         filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}_LTP.png"
@@ -237,178 +331,254 @@ def plot_LTP(pf_pc_conns, data, weight_matrix, IO, PC, GrC, corrected_cf_tms, cf
         plt.savefig(filename)
 
         if test_n == 9:
-            fig, ax = plt.subplots(3,1)
+            fig, ax = plt.subplots(3, 1)
 
             LTD_idx = np.array(np.where(np.diff(result_weights) < 0.0))
             LTD_values = np.diff(result_weights)[LTD_idx]
             print(type(LTD_idx))
             print(LTD_values)
 
-            ax[0].plot(data["events"]["times"][indices], result_weights, '*--')
+            ax[0].plot(data["events"]["times"][indices], result_weights, "*--")
             ax[0].set_ylabel("Synaptic weight")
-            #ax[1].plot(data["events"]["times"][indices][:-1], np.diff(result_weights))
-            
-            ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[1].scatter(simple_PC_times, target_id*np.ones(len(simple_PC_times)), label='Simple PC')
-            ax[1].scatter(complex_PC_times, target_id*np.ones(len(complex_PC_times)), color="red", label='Complex spikes')
-            ax[1].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
-            #ax[1].scatter(complex_PC_times, source_id*np.ones(len(complex_PC_times)), color = "white")
-            ax[2].legend(fontsize='small')
+            # ax[1].plot(data["events"]["times"][indices][:-1], np.diff(result_weights))
+
+            ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+            ax[1].scatter(
+                simple_PC_times,
+                target_id * np.ones(len(simple_PC_times)),
+                label="Simple PC",
+            )
+            ax[1].scatter(
+                complex_PC_times,
+                target_id * np.ones(len(complex_PC_times)),
+                color="red",
+                label="Complex spikes",
+            )
+            ax[1].scatter(
+                simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+            )
+            # ax[1].scatter(complex_PC_times, source_id*np.ones(len(complex_PC_times)), color = "white")
+            ax[2].legend(fontsize="small")
             ax[1].set_ylim(0, 5)
             ax[1].set_xlabel("Time [ms]")
             ax[1].set_ylabel("Neuron gID")
             ax[2].plot(LTD_idx.flatten(), -LTD_values.flatten())
-            ax[2].set_ylabel('LTD amount')
+            ax[2].set_ylabel("LTD amount")
 
-            subplot_labels = ['A', 'B', 'C']
+            subplot_labels = ["A", "B", "C"]
             for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
+                axs.text(
+                    -0.1,
+                    1.1,
+                    subplot_labels[i],
+                    transform=axs.transAxes,
+                    fontsize=16,
+                    fontweight="bold",
+                    va="top",
+                    ha="right",
+                )
+                ax[i].spines["top"].set_visible(False)
+                ax[i].spines["right"].set_visible(False)
+                ax[i].spines["bottom"].set_visible(True)
+                ax[i].spines["left"].set_visible(True)
 
             filename = f"{directory}/LTP_LTD.png"
             os.makedirs(directory, exist_ok=True)
             plt.tight_layout()
             plt.savefig(filename)
 
-def plot_LTD(pf_pc_conns, data, weight_matrix, IO, PC, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, test_n):
-    senders = data['events']['senders']
-    targets = data['events']['targets']
-    weights = data['events']['weights']
-    #print(data['events'])
+
+def plot_LTD(
+    pf_pc_conns,
+    data,
+    weight_matrix,
+    IO,
+    PC,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_PC_tms,
+    PC_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    weights = data["events"]["weights"]
+    # print(data['events'])
     for conn in pf_pc_conns:
 
-        #print(conn)
+        # print(conn)
         N = len(PC)
         source_id = conn.get("source")
         target_id = conn.get("target")
-        #print("source_id: ", source_id)
-        #print("starget_id: ", target_id)
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
 
         indices = np.where((senders == source_id) & (targets == target_id))
         result_weights = weights[indices]
 
         # Find IO corresponding to PC
-        connection = nest.GetConnections(source = IO, target = PC[target_id - N-1])
+        connection = nest.GetConnections(source=IO, target=PC[target_id - N - 1])
         IO_sender = connection.get("source")
-        #print("Corresponding IO: ", IO_sender)
-        
+        # print("Corresponding IO: ", IO_sender)
+
         # Get the spikes of IO, Gr and PC
         IO_times_tot = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-        #print("IO spikes: ", IO_times)
-        
+        # print("IO spikes: ", IO_times)
+
         total_PC_times = [t for t, e in zip(corrected_PC_tms, PC_evs) if e == target_id]
-        complex_PC_times_tot = [t for t in total_PC_times if t-1.0 in IO_times_tot]
-        print('complex times: ', complex_PC_times_tot)
-        simple_PC_times_tot = [t for t in total_PC_times if t not in complex_PC_times_tot]
-        #print("Pc simple spikes: ", simple_PC_times)
-        #print("Pc complex spikes: ", complex_PC_times)
+        complex_PC_times_tot = [t for t in total_PC_times if t - 1.0 in IO_times_tot]
+        print("complex times: ", complex_PC_times_tot)
+        simple_PC_times_tot = [
+            t for t in total_PC_times if t not in complex_PC_times_tot
+        ]
+        # print("Pc simple spikes: ", simple_PC_times)
+        # print("Pc complex spikes: ", complex_PC_times)
 
         first_complex_spike = complex_PC_times_tot[0]
-        first_complex_step = int(first_complex_spike/0.1)
+        first_complex_step = int(first_complex_spike / 0.1)
 
-        total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
         complex_Gr_times = [t for t in total_Gr_times if t in complex_PC_times_tot]
         simple_Gr_times_tot = [t for t in total_Gr_times if t not in complex_Gr_times]
-        #print("Simple Gr spikes: ", simple_Gr_times)
-        #print("Complex Gr spikes: ", complex_Gr_times)
-        #assert(simple_Gr_times)
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
         # Plot weight and spikes
 
         LTD_idx = np.array(np.where(np.diff(result_weights) < 0.0))
         LTD_values = np.diff(result_weights)[LTD_idx]
-        #print(type(LTD_idx))
-        #print(LTD_values)
+        # print(type(LTD_idx))
+        # print(LTD_values)
 
         for num_window, cs in enumerate(complex_PC_times_tot):
-            print('num window: ', num_window)
+            print("num window: ", num_window)
             end = cs + 50
             start = cs - 202.0
 
             time_window = np.arange(start, end, 0.1)
             print("time_window: ", time_window)
-            
-            weight_indices = np.where((data["events"]["times"] >= time_window[0]) & (data["events"]["times"] <= time_window[-1]))
-            #print(data["events"]["times"])
-            weight_times = data["events"]["times"][weight_indices]
-            print('weight_times: ', weight_times)
-            print('weights: ', result_weights[weight_indices])
 
-            #print('IO_times prima array: ', IO_times)
+            weight_indices = np.where(
+                (data["events"]["times"] >= time_window[0])
+                & (data["events"]["times"] <= time_window[-1])
+            )
+            # print(data["events"]["times"])
+            weight_times = data["events"]["times"][weight_indices]
+            print("weight_times: ", weight_times)
+            print("weights: ", result_weights[weight_indices])
+
+            # print('IO_times prima array: ', IO_times)
             IO_times = np.array(IO_times_tot)
-            #print('IO_times dopo array: ', IO_times)
-            IO_indices = np.where((IO_times >= time_window[0]) & (IO_times <= time_window[-1]))
+            # print('IO_times dopo array: ', IO_times)
+            IO_indices = np.where(
+                (IO_times >= time_window[0]) & (IO_times <= time_window[-1])
+            )
             IO_times = IO_times[IO_indices]
-            print('IO_times: ', IO_times)
+            print("IO_times: ", IO_times)
 
             simple_PC_times = np.array(simple_PC_times_tot)
-            simple_PC_indices = np.where((simple_PC_times >= time_window[0]) & (simple_PC_times <= time_window[-1]))
+            simple_PC_indices = np.where(
+                (simple_PC_times >= time_window[0])
+                & (simple_PC_times <= time_window[-1])
+            )
             simple_PC_times = simple_PC_times[simple_PC_indices]
-            print('simple PC times: ', simple_PC_times)
+            print("simple PC times: ", simple_PC_times)
 
             complex_PC_times = np.array(complex_PC_times_tot)
-            complex_PC_indices = np.where((complex_PC_times >= time_window[0]) & (complex_PC_times <= time_window[-1]))
+            complex_PC_indices = np.where(
+                (complex_PC_times >= time_window[0])
+                & (complex_PC_times <= time_window[-1])
+            )
             complex_PC_times = complex_PC_times[complex_PC_indices]
-            print('complex PC times: ', complex_PC_times)
+            print("complex PC times: ", complex_PC_times)
 
             simple_Gr_times = np.array(simple_Gr_times_tot)
-            simple_Gr_indices = np.where((simple_Gr_times >= time_window[0]) & (simple_Gr_times <= time_window[-1]))
+            simple_Gr_indices = np.where(
+                (simple_Gr_times >= time_window[0])
+                & (simple_Gr_times <= time_window[-1])
+            )
             simple_Gr_times = simple_Gr_times[simple_Gr_indices]
-            print('Gr times: ', simple_Gr_times)
+            print("Gr times: ", simple_Gr_times)
 
             result_weights = weight_matrix[int(math.floor(start)) : int(math.ceil(end))]
-            interpolator = interp1d(np.arange(len(result_weights))+start, result_weights, kind='linear')  # Linear interpolation
+            interpolator = interp1d(
+                np.arange(len(result_weights)) + start, result_weights, kind="linear"
+            )  # Linear interpolation
 
             # Compute interpolated values
-            values_high_res = interpolator(np.arange(len(result_weights))+start)
-            
-            fig, ax = plt.subplots(3,1, figsize = (8, 8), sharex=True)
-            #ax[0].plot(weight_times, result_weights[weight_indices], linewidth = 4)
-            ax[0].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[0].scatter(simple_PC_times, target_id*np.ones(len(simple_PC_times)), label='Simple PC')
-            ax[0].scatter(complex_PC_times, target_id*np.ones(len(complex_PC_times)), color="red", label='Complex spikes')
-            ax[0].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
+            values_high_res = interpolator(np.arange(len(result_weights)) + start)
+
+            fig, ax = plt.subplots(3, 1, figsize=(8, 8), sharex=True)
+            # ax[0].plot(weight_times, result_weights[weight_indices], linewidth = 4)
+            ax[0].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+            ax[0].scatter(
+                simple_PC_times,
+                target_id * np.ones(len(simple_PC_times)),
+                label="Simple PC",
+            )
+            ax[0].scatter(
+                complex_PC_times,
+                target_id * np.ones(len(complex_PC_times)),
+                color="red",
+                label="Complex spikes",
+            )
+            ax[0].scatter(
+                simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+            )
             ax[0].set_ylim(0, 8)
-            #ax[1].set_xlim(start, end)
+            # ax[1].set_xlim(start, end)
             ax[0].set_xlabel("Time [ms]")
             ax[0].set_ylabel("Neuron gID")
-            ax[0].legend(fontsize = 'small')
+            ax[0].legend(fontsize="small")
             ax[0].tick_params(labelbottom=True)
-            #ax[0].axhline(result_weights[weight_indices][0], xmin=0, xmax=1, color = 'k', linestyle='--')
-            #ax[0].axhline(result_weights[weight_indices][-1], xmin=0, xmax=1, color = 'k', linestyle='--')
-            #ax[1].plot(data["events"]["times"][indices][:-1], np.diff(result_weights))
-            
-            ax[1].plot(np.arange(len(result_weights))+start, values_high_res)
+            # ax[0].axhline(result_weights[weight_indices][0], xmin=0, xmax=1, color = 'k', linestyle='--')
+            # ax[0].axhline(result_weights[weight_indices][-1], xmin=0, xmax=1, color = 'k', linestyle='--')
+            # ax[1].plot(data["events"]["times"][indices][:-1], np.diff(result_weights))
+
+            ax[1].plot(np.arange(len(result_weights)) + start, values_high_res)
             ax[1].set_ylabel("Synaptic weight")
             ax[1].set_xlabel("Time [ms]")
-            ax[1].set_ylim((0.14,0.4))
+            ax[1].set_ylim((0.14, 0.4))
             ax[1].tick_params(labelbottom=True)
 
-            ax[2].plot(np.arange(len(result_weights))[:-1]+start, np.diff(values_high_res), 'k--')
+            ax[2].plot(
+                np.arange(len(result_weights))[:-1] + start,
+                np.diff(values_high_res),
+                "k--",
+            )
             ax[2].set_ylabel("Diff weight")
-            ax[2].set_ylim((-1.7,1.2))
+            ax[2].set_ylim((-1.7, 1.2))
             ax[2].set_xlabel("Time [ms]")
             ax[2].tick_params(labelbottom=True)
 
-            subplot_labels = ['A', 'B', 'C']
+            subplot_labels = ["A", "B", "C"]
             for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
+                axs.text(
+                    -0.1,
+                    1.1,
+                    subplot_labels[i],
+                    transform=axs.transAxes,
+                    fontsize=16,
+                    fontweight="bold",
+                    va="top",
+                    ha="right",
+                )
+                ax[i].spines["top"].set_visible(False)
+                ax[i].spines["right"].set_visible(False)
+                ax[i].spines["bottom"].set_visible(True)
+                ax[i].spines["left"].set_visible(True)
 
             directory = f"figures_plasticity_sinexp/test_{test_n}"
             filename = f"{directory}/window_{num_window}.png"
             os.makedirs(directory, exist_ok=True)
             plt.tight_layout()
             plt.savefig(filename)
-        
-            
+
 
 def reformat_weights(weights):
     total_steps = len(weights)
@@ -416,247 +586,380 @@ def reformat_weights(weights):
     weight_matrix = np.zeros((n_conns, total_steps))
     for timestep in range(total_steps):
         for conn in range(n_conns):
-            weight_matrix[conn, timestep] =round(weights[timestep][conn], 3)
-    
+            weight_matrix[conn, timestep] = round(weights[timestep][conn], 3)
+
     return weight_matrix
 
-def plot_synaptic_matrix(pf_pc_conns, data, weight_matrix, IO, PC, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, test_n):
-    senders = data['events']['senders']
-    targets = data['events']['targets']
-    #weights = data['events']['weights']
-    #print(data['events'])
+
+def plot_synaptic_matrix(
+    pf_pc_conns,
+    data,
+    weight_matrix,
+    IO,
+    PC,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_PC_tms,
+    PC_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    # weights = data['events']['weights']
+    # print(data['events'])
     for idx, conn in enumerate(pf_pc_conns):
-        #print(conn)
+        # print(conn)
         N = len(PC)
         source_id = conn.get("source")
         target_id = conn.get("target")
-        #print("source_id: ", source_id)
-        #print("starget_id: ", target_id)
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
 
         indices = np.where((senders == source_id) & (targets == target_id))
-        #print(type(weight_matrix))
-        #print(np.shape(weight_matrix))
+        # print(type(weight_matrix))
+        # print(np.shape(weight_matrix))
         result_weights = weight_matrix[idx, :]
 
         # Find IO corresponding to PC
-        connection = nest.GetConnections(source = IO, target = PC[target_id - N-1])
+        connection = nest.GetConnections(source=IO, target=PC[target_id - N - 1])
         IO_sender = connection.get("source")
-        #print("Corresponding IO: ", IO_sender)
-        
+        # print("Corresponding IO: ", IO_sender)
+
         # Get the spikes of IO, Gr and PC
         IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-        #print("IO spikes: ", IO_times)
-        
-        total_PC_times = [t for t, e in zip(corrected_PC_tms, PC_evs) if e == target_id]
-        complex_PC_times = [t for t in total_PC_times if t-1.0 in IO_times]
-        simple_PC_times = [t for t in total_PC_times if t not in complex_PC_times]
-        #print("Pc simple spikes: ", simple_PC_times)
-        #print("Pc complex spikes: ", complex_PC_times)
+        # print("IO spikes: ", IO_times)
 
-        total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
+        total_PC_times = [t for t, e in zip(corrected_PC_tms, PC_evs) if e == target_id]
+        complex_PC_times = [t for t in total_PC_times if t - 1.0 in IO_times]
+        simple_PC_times = [t for t in total_PC_times if t not in complex_PC_times]
+        # print("Pc simple spikes: ", simple_PC_times)
+        # print("Pc complex spikes: ", complex_PC_times)
+
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
         complex_Gr_times = [t for t in total_Gr_times if t in complex_PC_times]
         simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
-        #print("Simple Gr spikes: ", simple_Gr_times)
-        #print("Complex Gr spikes: ", complex_Gr_times)
-        #assert(simple_Gr_times)
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
         # Plot weight and spikes
         directory = f"figures_plasticity_sinexp/test_{test_n}"
         if test_n != 9:
-            fig, ax = plt.subplots(2,1)
-            ax[0].plot(np.arange(1000), result_weights, '--')
+            fig, ax = plt.subplots(2, 1)
+            ax[0].plot(np.arange(1000), result_weights, "--")
             ax[0].set_ylabel("Synaptic weight")
-            ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[1].scatter(simple_PC_times, target_id*np.ones(len(simple_PC_times)), label='Simple PC')
-            ax[1].scatter(complex_PC_times, target_id*np.ones(len(complex_PC_times)), color="red", label='Complex spikes')
-            ax[1].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
-            ax[1].scatter(complex_PC_times, source_id*np.ones(len(complex_PC_times)), color = "white", s = 70)
-            ax[1].legend(fontsize='small')
+            ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+            ax[1].scatter(
+                simple_PC_times,
+                target_id * np.ones(len(simple_PC_times)),
+                label="Simple PC",
+            )
+            ax[1].scatter(
+                complex_PC_times,
+                target_id * np.ones(len(complex_PC_times)),
+                color="red",
+                label="Complex spikes",
+            )
+            ax[1].scatter(
+                simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+            )
+            ax[1].scatter(
+                complex_PC_times,
+                source_id * np.ones(len(complex_PC_times)),
+                color="white",
+                s=70,
+            )
+            ax[1].legend(fontsize="small")
             ax[1].set_ylim(0, 20)
             ax[1].set_xlabel("Time [ms]")
             ax[1].set_ylabel("Neuron gID")
 
-            subplot_labels = ['A', 'B']
+            subplot_labels = ["A", "B"]
             for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
-                
+                axs.text(
+                    -0.1,
+                    1.1,
+                    subplot_labels[i],
+                    transform=axs.transAxes,
+                    fontsize=16,
+                    fontweight="bold",
+                    va="top",
+                    ha="right",
+                )
+                ax[i].spines["top"].set_visible(False)
+                ax[i].spines["right"].set_visible(False)
+                ax[i].spines["bottom"].set_visible(True)
+                ax[i].spines["left"].set_visible(True)
+
             filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
             os.makedirs(directory, exist_ok=True)
 
         else:
-            fig, ax = plt.subplots(3,1)
+            fig, ax = plt.subplots(3, 1)
 
-            ax[0].plot(np.arange(4300), result_weights, '--')
+            ax[0].plot(np.arange(4300), result_weights, "--")
             ax[0].set_ylabel("Synaptic weight")
             ax[1].plot(np.arange(4299), np.diff(result_weights))
-            ax[1].set_ylabel('Weight change')
-            ax[2].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[2].scatter(simple_PC_times, target_id*np.ones(len(simple_PC_times)), label='Simple PC')
-            ax[2].scatter(complex_PC_times, target_id*np.ones(len(complex_PC_times)), color="red", label='Complex spikes')
-            ax[2].scatter(simple_Gr_times, source_id*np.ones(len(simple_Gr_times)), label='GrCs')
-            #ax[2].scatter(complex_PC_times, source_id*np.ones(len(complex_PC_times)), color = "white")
-            ax[2].legend(fontsize='small')
+            ax[1].set_ylabel("Weight change")
+            ax[2].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+            ax[2].scatter(
+                simple_PC_times,
+                target_id * np.ones(len(simple_PC_times)),
+                label="Simple PC",
+            )
+            ax[2].scatter(
+                complex_PC_times,
+                target_id * np.ones(len(complex_PC_times)),
+                color="red",
+                label="Complex spikes",
+            )
+            ax[2].scatter(
+                simple_Gr_times, source_id * np.ones(len(simple_Gr_times)), label="GrCs"
+            )
+            # ax[2].scatter(complex_PC_times, source_id*np.ones(len(complex_PC_times)), color = "white")
+            ax[2].legend(fontsize="small")
             ax[2].set_ylim(0, 20)
             ax[2].set_xlabel("Time [ms]")
             ax[2].set_ylabel("Neuron gID")
 
-            subplot_labels = ['A', 'B', 'C']
+            subplot_labels = ["A", "B", "C"]
             for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
+                axs.text(
+                    -0.1,
+                    1.1,
+                    subplot_labels[i],
+                    transform=axs.transAxes,
+                    fontsize=16,
+                    fontweight="bold",
+                    va="top",
+                    ha="right",
+                )
+                ax[i].spines["top"].set_visible(False)
+                ax[i].spines["right"].set_visible(False)
+                ax[i].spines["bottom"].set_visible(True)
+                ax[i].spines["left"].set_visible(True)
 
             filename = f"{directory}/LTP_LTD.png"
             os.makedirs(directory, exist_ok=True)
         plt.tight_layout()
         plt.savefig(filename)
-    
-def plot_simple_spike(pf_pc_conns, data, weight_matrix, IO, PC, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, test_n):
-        senders = data['events']['senders']
-        targets = data['events']['targets']
-        #weights = data['events']['weights']
-        #print(data['events'])
-        for idx, conn in enumerate(pf_pc_conns):
-            #print(conn)
-            N = len(PC)
-            source_id = conn.get("source")
-            target_id = conn.get("target")
-            #print("source_id: ", source_id)
-            #print("starget_id: ", target_id)
 
-            indices = np.where((senders == source_id) & (targets == target_id))
-            #print(type(weight_matrix))
-            #print(np.shape(weight_matrix))
-            result_weights = weight_matrix[idx, :]
 
-            # Find IO corresponding to PC
-            connection = nest.GetConnections(source = IO, target = PC[target_id - N-1])
-            IO_sender = connection.get("source")
-            #print("Corresponding IO: ", IO_sender)
-            
-            # Get the spikes of IO, Gr and PC
-            IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-            #print("IO spikes: ", IO_times)
-            
-            total_PC_times = [t for t, e in zip(corrected_PC_tms, PC_evs) if e == target_id]
-            complex_PC_times = [t for t in total_PC_times if t-1.0 in IO_times]
-            simple_PC_times = [t for t in total_PC_times if t not in complex_PC_times]
-            #print("Pc simple spikes: ", simple_PC_times)
-            #print("Pc complex spikes: ", complex_PC_times)
+def plot_simple_spike(
+    pf_pc_conns,
+    data,
+    weight_matrix,
+    IO,
+    PC,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_PC_tms,
+    PC_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    # weights = data['events']['weights']
+    # print(data['events'])
+    for idx, conn in enumerate(pf_pc_conns):
+        # print(conn)
+        N = len(PC)
+        source_id = conn.get("source")
+        target_id = conn.get("target")
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
 
-            total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
-            complex_Gr_times = [t for t in total_Gr_times if t in complex_PC_times]
-            simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
-            #print("Simple Gr spikes: ", simple_Gr_times)
-            #print("Complex Gr spikes: ", complex_Gr_times)
-            #assert(simple_Gr_times)
-            # Plot weight and spikes
-            fig, ax = plt.subplots(2,1)
-            ax[0].plot(np.arange(1000), result_weights, '--')
-            ax[0].set_ylabel("Synaptic weight")
-            ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[1].scatter(simple_PC_times, target_id*np.ones(len(simple_PC_times)), label='Simple PC')
-            ax[1].scatter(complex_PC_times, target_id*np.ones(len(complex_PC_times)), color="red", label='Complex PC')
-            ax[1].scatter(simple_Gr_times[-1], source_id*np.ones(len(simple_Gr_times))[-1], label='Simple GR')
-            ax[1].legend(fontsize='small')
-            ax[1].set_ylim(0, 12)
-            ax[1].set_xlabel("Time [ms]")
-            ax[1].set_ylabel("Neuron gID")
+        indices = np.where((senders == source_id) & (targets == target_id))
+        # print(type(weight_matrix))
+        # print(np.shape(weight_matrix))
+        result_weights = weight_matrix[idx, :]
 
-            subplot_labels = ['A', 'B']
-            for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
+        # Find IO corresponding to PC
+        connection = nest.GetConnections(source=IO, target=PC[target_id - N - 1])
+        IO_sender = connection.get("source")
+        # print("Corresponding IO: ", IO_sender)
 
-            directory = f"figures_plasticity_sinexp/test_{test_n}"
-            filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
-            os.makedirs(directory, exist_ok=True)
-            plt.tight_layout()
-            plt.savefig(filename)
+        # Get the spikes of IO, Gr and PC
+        IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
+        # print("IO spikes: ", IO_times)
 
-def plot_complex_spike(pf_pc_conns, data, weight_matrix, IO, PC, GrC, corrected_cf_tms, cf_evs, corrected_gr_spikes, Gr_evs, corrected_PC_tms, PC_evs, test_n):
-        senders = data['events']['senders']
-        targets = data['events']['targets']
-        #weights = data['events']['weights']
-        #print(data['events'])
-        for idx, conn in enumerate(pf_pc_conns):
-            #print(conn)
-            N = len(PC)
-            source_id = conn.get("source")
-            target_id = conn.get("target")
-            #print("source_id: ", source_id)
-            #print("starget_id: ", target_id)
+        total_PC_times = [t for t, e in zip(corrected_PC_tms, PC_evs) if e == target_id]
+        complex_PC_times = [t for t in total_PC_times if t - 1.0 in IO_times]
+        simple_PC_times = [t for t in total_PC_times if t not in complex_PC_times]
+        # print("Pc simple spikes: ", simple_PC_times)
+        # print("Pc complex spikes: ", complex_PC_times)
 
-            indices = np.where((senders == source_id) & (targets == target_id))
-            #print(type(weight_matrix))
-            #print(np.shape(weight_matrix))
-            result_weights = weight_matrix[idx, :]
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
+        complex_Gr_times = [t for t in total_Gr_times if t in complex_PC_times]
+        simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
+        # Plot weight and spikes
+        fig, ax = plt.subplots(2, 1)
+        ax[0].plot(np.arange(1000), result_weights, "--")
+        ax[0].set_ylabel("Synaptic weight")
+        ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+        ax[1].scatter(
+            simple_PC_times,
+            target_id * np.ones(len(simple_PC_times)),
+            label="Simple PC",
+        )
+        ax[1].scatter(
+            complex_PC_times,
+            target_id * np.ones(len(complex_PC_times)),
+            color="red",
+            label="Complex PC",
+        )
+        ax[1].scatter(
+            simple_Gr_times[-1],
+            source_id * np.ones(len(simple_Gr_times))[-1],
+            label="Simple GR",
+        )
+        ax[1].legend(fontsize="small")
+        ax[1].set_ylim(0, 12)
+        ax[1].set_xlabel("Time [ms]")
+        ax[1].set_ylabel("Neuron gID")
 
-            # Find IO corresponding to PC
-            connection = nest.GetConnections(source = IO, target = PC[target_id - N-1])
-            IO_sender = connection.get("source")
-            #print("Corresponding IO: ", IO_sender)
-            
-            # Get the spikes of IO, Gr and PC
-            IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
-            #print("IO spikes: ", IO_times)
-            
-            total_PC_times = [t for t, e in zip(corrected_PC_tms, PC_evs) if e == target_id]
-            complex_PC_times = [t for t in total_PC_times if t-1.0 in IO_times]
-            simple_PC_times = [t for t in total_PC_times if t not in complex_PC_times]
-            #print("Pc simple spikes: ", simple_PC_times)
-            #print("Pc complex spikes: ", complex_PC_times)
+        subplot_labels = ["A", "B"]
+        for i, axs in enumerate(ax):
+            axs.text(
+                -0.1,
+                1.1,
+                subplot_labels[i],
+                transform=axs.transAxes,
+                fontsize=16,
+                fontweight="bold",
+                va="top",
+                ha="right",
+            )
+            ax[i].spines["top"].set_visible(False)
+            ax[i].spines["right"].set_visible(False)
+            ax[i].spines["bottom"].set_visible(True)
+            ax[i].spines["left"].set_visible(True)
 
-            total_Gr_times = [t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id]
-            complex_Gr_times = [t for t in total_Gr_times if t in complex_PC_times]
-            simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
-            #print("Simple Gr spikes: ", simple_Gr_times)
-            #print("Complex Gr spikes: ", complex_Gr_times)
-            #assert(simple_Gr_times)
-            # Plot weight and spikes
-            fig, ax = plt.subplots(2,1)
-            ax[0].plot(np.arange(1000), result_weights, '--')
-            ax[0].set_ylabel("Synaptic weight")
-            ax[1].scatter(IO_times, IO_sender*np.ones(len(IO_times)), label='IO')
-            ax[1].scatter(simple_PC_times, target_id*np.ones(len(simple_PC_times)), label='Simple PC')
-            ax[1].scatter(complex_PC_times, target_id*np.ones(len(complex_PC_times)), color="red", label='Complex spikes')
-            #ax[1].scatter(total_Gr_times[-1], source_id*np.ones(len(total_Gr_times))[-1], color = "red")
-            ax[1].legend(fontsize='small')
-            ax[1].set_ylim(0, 12)
-            ax[1].set_xlabel("Time [ms]")
-            ax[1].set_ylabel("Neuron gID")
+        directory = f"figures_plasticity_sinexp/test_{test_n}"
+        filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
+        os.makedirs(directory, exist_ok=True)
+        plt.tight_layout()
+        plt.savefig(filename)
 
-            subplot_labels = ['A', 'B']
-            for i, axs in enumerate(ax):
-                axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-                    fontsize=16, fontweight='bold', va='top', ha='right')
-                ax[i].spines['top'].set_visible(False)
-                ax[i].spines['right'].set_visible(False)
-                ax[i].spines['bottom'].set_visible(True)
-                ax[i].spines['left'].set_visible(True)
 
-            directory = f"figures_plasticity_sinexp/test_{test_n}"
-            filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
-            os.makedirs(directory, exist_ok=True)
-            plt.tight_layout()
-            plt.savefig(filename)
+def plot_complex_spike(
+    pf_pc_conns,
+    data,
+    weight_matrix,
+    IO,
+    PC,
+    GrC,
+    corrected_cf_tms,
+    cf_evs,
+    corrected_gr_spikes,
+    Gr_evs,
+    corrected_PC_tms,
+    PC_evs,
+    test_n,
+):
+    senders = data["events"]["senders"]
+    targets = data["events"]["targets"]
+    # weights = data['events']['weights']
+    # print(data['events'])
+    for idx, conn in enumerate(pf_pc_conns):
+        # print(conn)
+        N = len(PC)
+        source_id = conn.get("source")
+        target_id = conn.get("target")
+        # print("source_id: ", source_id)
+        # print("starget_id: ", target_id)
+
+        indices = np.where((senders == source_id) & (targets == target_id))
+        # print(type(weight_matrix))
+        # print(np.shape(weight_matrix))
+        result_weights = weight_matrix[idx, :]
+
+        # Find IO corresponding to PC
+        connection = nest.GetConnections(source=IO, target=PC[target_id - N - 1])
+        IO_sender = connection.get("source")
+        # print("Corresponding IO: ", IO_sender)
+
+        # Get the spikes of IO, Gr and PC
+        IO_times = [t for t, e in zip(corrected_cf_tms, cf_evs) if e == IO_sender]
+        # print("IO spikes: ", IO_times)
+
+        total_PC_times = [t for t, e in zip(corrected_PC_tms, PC_evs) if e == target_id]
+        complex_PC_times = [t for t in total_PC_times if t - 1.0 in IO_times]
+        simple_PC_times = [t for t in total_PC_times if t not in complex_PC_times]
+        # print("Pc simple spikes: ", simple_PC_times)
+        # print("Pc complex spikes: ", complex_PC_times)
+
+        total_Gr_times = [
+            t for t, e in zip(corrected_gr_spikes, Gr_evs) if e == source_id
+        ]
+        complex_Gr_times = [t for t in total_Gr_times if t in complex_PC_times]
+        simple_Gr_times = [t for t in total_Gr_times if t not in complex_Gr_times]
+        # print("Simple Gr spikes: ", simple_Gr_times)
+        # print("Complex Gr spikes: ", complex_Gr_times)
+        # assert(simple_Gr_times)
+        # Plot weight and spikes
+        fig, ax = plt.subplots(2, 1)
+        ax[0].plot(np.arange(1000), result_weights, "--")
+        ax[0].set_ylabel("Synaptic weight")
+        ax[1].scatter(IO_times, IO_sender * np.ones(len(IO_times)), label="IO")
+        ax[1].scatter(
+            simple_PC_times,
+            target_id * np.ones(len(simple_PC_times)),
+            label="Simple PC",
+        )
+        ax[1].scatter(
+            complex_PC_times,
+            target_id * np.ones(len(complex_PC_times)),
+            color="red",
+            label="Complex spikes",
+        )
+        # ax[1].scatter(total_Gr_times[-1], source_id*np.ones(len(total_Gr_times))[-1], color = "red")
+        ax[1].legend(fontsize="small")
+        ax[1].set_ylim(0, 12)
+        ax[1].set_xlabel("Time [ms]")
+        ax[1].set_ylabel("Neuron gID")
+
+        subplot_labels = ["A", "B"]
+        for i, axs in enumerate(ax):
+            axs.text(
+                -0.1,
+                1.1,
+                subplot_labels[i],
+                transform=axs.transAxes,
+                fontsize=16,
+                fontweight="bold",
+                va="top",
+                ha="right",
+            )
+            ax[i].spines["top"].set_visible(False)
+            ax[i].spines["right"].set_visible(False)
+            ax[i].spines["bottom"].set_visible(True)
+            ax[i].spines["left"].set_visible(True)
+
+        directory = f"figures_plasticity_sinexp/test_{test_n}"
+        filename = f"{directory}/synapse_sender_{source_id}_target_{target_id}.png"
+        os.makedirs(directory, exist_ok=True)
+        plt.tight_layout()
+        plt.savefig(filename)
+
 
 def correct_spike_times(cf_recorder, PC_recorder, Gr_recorder):
     cf_spikes = nest.GetStatus(cf_recorder)[0]["events"]
     cf_tms = cf_spikes["times"]
     cf_evs = cf_spikes["senders"]
-    #print('evs inside function: ', cf_evs)
+    # print('evs inside function: ', cf_evs)
 
     PC_spikes = nest.GetStatus(PC_recorder)[0]["events"]
     PC_tms = PC_spikes["times"]
@@ -673,25 +976,38 @@ def correct_spike_times(cf_recorder, PC_recorder, Gr_recorder):
         corrected_cf_tms.append(corrected_time)
 
     corrected_cf_tms = [round(t, 1) for t in corrected_cf_tms]
-    #print('cf spikes: (', corrected_cf_tms, '), (', cf_evs, ')')
+    # print('cf spikes: (', corrected_cf_tms, '), (', cf_evs, ')')
 
     # Purkinje cells
     corrected_PC_tms = []
     for idx, (time, sender) in enumerate(zip(PC_tms, PC_evs)):
-        corrected_time = time + (sender - min(PC_evs) +1)
+        corrected_time = time + (sender - min(PC_evs) + 1)
         corrected_PC_tms.append(corrected_time)
 
     corrected_PC_tms = [round(t, 1) for t in corrected_PC_tms]
-    #print('PC spikes: (', corrected_PC_tms, '), (', PC_evs, ')\n')
-    
-    PC_complex_tms = [spike for spike in corrected_PC_tms if (spike - 1.0) in corrected_cf_tms]
-    PC_complex_evs = [ev for (spike, ev) in zip(corrected_PC_tms, PC_evs) if spike in PC_complex_tms]
-    #print('Complex PC spikes: (', PC_complex_tms, '), (', PC_complex_evs, ')\n')
+    # print('PC spikes: (', corrected_PC_tms, '), (', PC_evs, ')\n')
+
+    PC_complex_tms = [
+        spike for spike in corrected_PC_tms if (spike - 1.0) in corrected_cf_tms
+    ]
+    PC_complex_evs = [
+        ev for (spike, ev) in zip(corrected_PC_tms, PC_evs) if spike in PC_complex_tms
+    ]
+    # print('Complex PC spikes: (', PC_complex_tms, '), (', PC_complex_evs, ')\n')
 
     # Granule cells
     corrected_gr_spikes = [round(t + s, 1) for t, s in zip(Gr_tms, Gr_evs)]
-    assert(len(corrected_gr_spikes) == len(Gr_tms))
+    assert len(corrected_gr_spikes) == len(Gr_tms)
 
-    #print('Gr spikes: (', corrected_gr_spikes, '), (', Gr_evs, ')\n')
+    # print('Gr spikes: (', corrected_gr_spikes, '), (', Gr_evs, ')\n')
 
-    return corrected_cf_tms, cf_evs, corrected_PC_tms, PC_evs, PC_complex_tms, PC_complex_evs, corrected_gr_spikes, Gr_evs
+    return (
+        corrected_cf_tms,
+        cf_evs,
+        corrected_PC_tms,
+        PC_evs,
+        PC_complex_tms,
+        PC_complex_evs,
+        corrected_gr_spikes,
+        Gr_evs,
+    )

--- a/tests_POCs/rb/plotting.py
+++ b/tests_POCs/rb/plotting.py
@@ -1,77 +1,125 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-def plotPopulation_sd(time_v, N, firstID_p, firstID_n, pos_ts, pos_sds, neg_ts, neg_sds, reference, time_vecs, legend, styles, title='',buffer_size=15):
+
+def plotPopulation_sd(
+    time_v,
+    N,
+    firstID_p,
+    firstID_n,
+    pos_ts,
+    pos_sds,
+    neg_ts,
+    neg_sds,
+    reference,
+    time_vecs,
+    legend,
+    styles,
+    title="",
+    buffer_size=15,
+):
     y_p = pos_sds - firstID_p + 1
     y_n = -(neg_sds - firstID_n + 1)
     if not reference:
-        fig, ax = plt.subplots(2,1,sharex=True)
-        ax[0].scatter(pos_ts, y_p, marker='.', s=1,c="r", label = 'pos')
-        ax[0].scatter(neg_ts, y_n, marker='.', s=1, c= "b", label = 'neg')
+        fig, ax = plt.subplots(2, 1, sharex=True)
+        ax[0].scatter(pos_ts, y_p, marker=".", s=1, c="r", label="pos")
+        ax[0].scatter(neg_ts, y_n, marker=".", s=1, c="b", label="neg")
         ax[0].legend()
         ax[0].set_ylabel("raster")
-        rate_p = plot_rate_sd(time_v, N, pos_ts, pos_sds, buffer_size, ax=ax[1],color="r")
-        rate_n = plot_rate_sd(time_v, N, neg_ts, neg_sds, buffer_size, ax=ax[1], color = "b",title='PSTH (Hz)')
-        #ax[0].set_title(title)
-        ax[0].set_ylim( bottom=-(N+1), top=N+1 )
-        
+        rate_p = plot_rate_sd(
+            time_v, N, pos_ts, pos_sds, buffer_size, ax=ax[1], color="r"
+        )
+        rate_n = plot_rate_sd(
+            time_v,
+            N,
+            neg_ts,
+            neg_sds,
+            buffer_size,
+            ax=ax[1],
+            color="b",
+            title="PSTH (Hz)",
+        )
+        # ax[0].set_title(title)
+        ax[0].set_ylim(bottom=-(N + 1), top=N + 1)
+
     else:
-        fig, ax = plt.subplots(3,1,sharex=True)
+        fig, ax = plt.subplots(3, 1, sharex=True)
         for i, signal in enumerate(reference):
-            ax[0].plot(time_vecs[i], signal, styles[i],label=legend[i])
+            ax[0].plot(time_vecs[i], signal, styles[i], label=legend[i])
             ax[0].legend()
             ax[0].set_ylabel("input (Hz)")
-            #ax[0].axhline(y=0, color='k', linestyle='--')
-        ax[1].scatter(pos_ts, y_p, marker='.', s=1,c="r", label='pos')
-        ax[1].scatter(neg_ts, y_n, marker='.', s=1, color = "b", label='neg')
+            # ax[0].axhline(y=0, color='k', linestyle='--')
+        ax[1].scatter(pos_ts, y_p, marker=".", s=1, c="r", label="pos")
+        ax[1].scatter(neg_ts, y_n, marker=".", s=1, color="b", label="neg")
         ax[1].set_ylabel("raster")
-        ax[1].set_ylim( bottom=-(N+1), top=N+1 )
-        rate_p = plot_rate_sd(time_v, N, pos_ts, pos_sds, buffer_size, ax=ax[2],color="r", label='pos')
-        rate_n = plot_rate_sd(time_v, N, neg_ts, neg_sds, buffer_size, ax=ax[2], color = "b", title='PSTH (Hz)', label='neg')
-        #ax[1].set_title(title)
-        
-    subplot_labels = ['A', 'B', 'C']
+        ax[1].set_ylim(bottom=-(N + 1), top=N + 1)
+        rate_p = plot_rate_sd(
+            time_v, N, pos_ts, pos_sds, buffer_size, ax=ax[2], color="r", label="pos"
+        )
+        rate_n = plot_rate_sd(
+            time_v,
+            N,
+            neg_ts,
+            neg_sds,
+            buffer_size,
+            ax=ax[2],
+            color="b",
+            title="PSTH (Hz)",
+            label="neg",
+        )
+        # ax[1].set_title(title)
+
+    subplot_labels = ["A", "B", "C"]
     for i, axs in enumerate(ax):
-        axs.text(-0.1, 1.1, subplot_labels[i], transform=axs.transAxes,
-            fontsize=16, fontweight='bold', va='top', ha='right')
-        ax[i].spines['top'].set_visible(False)
-        ax[i].spines['right'].set_visible(False)
-        ax[i].spines['bottom'].set_visible(True)
-        ax[i].spines['left'].set_visible(True)
-    
-    
+        axs.text(
+            -0.1,
+            1.1,
+            subplot_labels[i],
+            transform=axs.transAxes,
+            fontsize=16,
+            fontweight="bold",
+            va="top",
+            ha="right",
+        )
+        ax[i].spines["top"].set_visible(False)
+        ax[i].spines["right"].set_visible(False)
+        ax[i].spines["bottom"].set_visible(True)
+        ax[i].spines["left"].set_visible(True)
 
     return fig, ax, rate_p, rate_n
 
-def plot_rate_sd(time, N, times, senders, buffer_sz=10, title='', ax=None, bar=True, **kwargs):
-        t_init = time[0]
-        t_end  = time[-1]
 
-        bins,count,rate = computePSTH_sd(time, N, times, buffer_sz)
-        #print(len(rate))
-        rate_padded = np.pad(rate, pad_width=2, mode='reflect') 
-        rate_sm = np.convolve(rate_padded, np.ones(5) / 5, mode='valid')
-    
-        no_ax = ax is None
-        if no_ax:
-            fig, ax = plt.subplots(1)
+def plot_rate_sd(
+    time, N, times, senders, buffer_sz=10, title="", ax=None, bar=True, **kwargs
+):
+    t_init = time[0]
+    t_end = time[-1]
 
-        if bar:
-            ax.bar(bins[:-1], rate, width=bins[1]-bins[0],**kwargs)
-            ax.plot(bins[:-1],rate_sm,color='k')
-        else:
-            ax.plot(bins[:-1],rate_sm,**kwargs)
-        ax.set(xlim=(t_init, t_end))
-        ax.set_ylabel(title)
-        ax.set_xlabel('Time [ms]')
-        
-    
-        return rate
+    bins, count, rate = computePSTH_sd(time, N, times, buffer_sz)
+    # print(len(rate))
+    rate_padded = np.pad(rate, pad_width=2, mode="reflect")
+    rate_sm = np.convolve(rate_padded, np.ones(5) / 5, mode="valid")
+
+    no_ax = ax is None
+    if no_ax:
+        fig, ax = plt.subplots(1)
+
+    if bar:
+        ax.bar(bins[:-1], rate, width=bins[1] - bins[0], **kwargs)
+        ax.plot(bins[:-1], rate_sm, color="k")
+    else:
+        ax.plot(bins[:-1], rate_sm, **kwargs)
+    ax.set(xlim=(t_init, t_end))
+    ax.set_ylabel(title)
+    ax.set_xlabel("Time [ms]")
+
+    return rate
+
 
 def computePSTH_sd(time, N, times, buffer_sz=10):
-        t_init = time[0]
-        t_end  = time[-1]
-        #print(np.shape(times))
-        count, bins = np.histogram( times, bins=np.arange(t_init,t_end+1,buffer_sz) )
-        rate = 1000*count/(N*buffer_sz)
-        return bins, count, rate
+    t_init = time[0]
+    t_end = time[-1]
+    # print(np.shape(times))
+    count, bins = np.histogram(times, bins=np.arange(t_init, t_end + 1, buffer_sz))
+    rate = 1000 * count / (N * buffer_sz)
+    return bins, count, rate


### PR DESCRIPTION
## Summary
- Run `black` formatter on all Python files (excluding submodules and nrp-core)
- 28 files reformatted

## Notes
Split from #86 / feat/ci to keep the CI/docker PR diff clean.