### PR TITLE
Publish minjerk to pypi

### DIFF
--- a/.github/workflows/publish-minjerk.yml
+++ b/.github/workflows/publish-minjerk.yml
@@ -1,0 +1,80 @@
+name: Publish minjerk-dynamics to PyPI
+
+on:
+  push:
+    paths:
+      - "complete_control/shared/minjerk/**"
+      - ".github/workflows/publish-minjerk.yml"
+
+jobs:
+  build:
+    name: Build minjerk-dynamics
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history is required so setuptools-scm can compute the version
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build wheel and sdist
+        working-directory: complete_control/shared/minjerk
+        run: python -m build
+
+      - name: Show built package info
+        working-directory: complete_control/shared/minjerk/dist
+        run: |
+          echo "=== Built artifacts ==="
+          for f in *; do
+            echo "File   : $f"
+            # name and version are the first two dash-separated fields of the stem
+            stem="${f%.*}"           # strip last extension
+            stem="${stem%.tar}"      # strip .tar for sdist (.tar.gz)
+            name="${stem%%-[0-9]*}"  # everything before the first -<digit>
+            version="${stem#${name}-}"
+            version="${version%%[-+.][a-zA-Z]*}"  # strip extra suffixes for display
+            echo "Name   : $name"
+            echo "Version: ${stem#${name}-}"
+            echo "---"
+          done
+
+      - name: Upload dist as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: minjerk-dist
+          path: complete_control/shared/minjerk/dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    # Only publish from main
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    # Required for OIDC Trusted Publishing (alternative to API token)
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: minjerk-dist
+          path: dist/
+
+      # Configure on PyPI: https://pypi.org/manage/account/publishing/
+      # Publisher settings: owner=<org>, repo=controller,
+      #   workflow=publish-minjerk.yml, env=(leave blank)
+      - name: Publish to PyPI (Trusted Publisher)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+

--- a/.github/workflows/publish-minjerk.yml
+++ b/.github/workflows/publish-minjerk.yml
@@ -5,6 +5,13 @@ on:
     paths:
       - "complete_control/shared/minjerk/**"
       - ".github/workflows/publish-minjerk.yml"
+  workflow_dispatch:
+    inputs:
+      publish_to_pypi:
+        description: "Publish built artifacts to PyPI (main branch only)"
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -56,8 +63,8 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: build
-    # Only publish from main
-    if: github.ref == 'refs/heads/main'
+    # Auto-publish on push to main; manual publish requires explicit opt-in.
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish_to_pypi)) }}
     runs-on: ubuntu-latest
     # Required for OIDC Trusted Publishing (alternative to API token)
     permissions:

--- a/.github/workflows/publish-minjerk.yml
+++ b/.github/workflows/publish-minjerk.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_to_pypi:
-        description: "Publish built artifacts to PyPI (main branch only)"
+        description: "Publish built artifacts to PyPI"
         required: true
         type: boolean
         default: false
@@ -63,8 +63,8 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: build
-    # Auto-publish on push to main; manual publish requires explicit opt-in.
-    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish_to_pypi)) }}
+    # Auto-publish on push to main; allow manual publish from any branch.
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.publish_to_pypi) }}
     runs-on: ubuntu-latest
     # Required for OIDC Trusted Publishing (alternative to API token)
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ target/state_MAD_neuron.cpp
 target/state_MAD_neuron.h
 tests_POCs/PLV_Emiliano.py
 tests_POCs/test_receptor_paolo.py
+
+*.whl
+complete_control/shared/minjerk/minjerk_dynamics/_version.py

--- a/complete_control/shared/minjerk/pyproject.toml
+++ b/complete_control/shared/minjerk/pyproject.toml
@@ -1,10 +1,20 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "minjerk-dynamics"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Minimum-jerk trajectory and 1-DOF inverse dynamics"
 requires-python = ">=3.10"
 dependencies = ["numpy"]
+
+[tool.setuptools_scm]
+# path to the git root relative to this pyproject.toml
+root = "../../.."
+# write version into a module so it is importable at runtime
+version_file = "minjerk_dynamics/_version.py"
+# drop the +gABCDEF local identifier so the version is accepted by PyPI
+local_scheme = "no-local-version"
+# used when git history is unavailable (e.g. a tarball download)
+fallback_version = "0.1.0"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -86,6 +86,12 @@ else
     echo "Uncompressed network file ${BSB_NETWORK_FILE} already exists. Skipping decompression."
 fi
 
+# setuptools-scm invokes git during editable installs; container bind-mount ownership
+# often differs from the active user, which triggers git's dubious ownership guard.
+if command -v git > /dev/null 2>&1; then
+    git config --global --add safe.directory "${CONTROLLER_DIR}" || true
+fi
+
 # --- Install shared packages (editable) ---
 pip install --quiet -e "${CONTROLLER_DIR}/complete_control/shared/minjerk"
 


### PR DESCRIPTION
Configure on PyPI: https://pypi.org/manage/account/publishing/
Publisher settings: owner=near-nes, repo=controller,
workflow=publish-minjerk.yml, env=(leave blank)


towards #124 